### PR TITLE
Add loadbefore for tab plugin

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: ${project.name}
 main: me.clip.placeholderapi.PlaceholderAPIPlugin
 version: ${project.version}
 author: [extended_clip]
+loadbefore: [TAB]
 description: ${project.description}
 permissions:
     placeholderapi.*:


### PR DESCRIPTION
This means that the plugin no longer has to be manually reloaded after server starts when using PAPI placeholders within the configuration.