### PR TITLE
1.13 tab-complete issue fix

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -36,7 +36,11 @@ permissions:
     placeholderapi.updatenotify:
         description: notifies you when there is a PAPI update
         default: op
+    placeholderapi.help:
+        description: grants access to the main placeholderapi commands
+        default: op
 commands:
    placeholderapi:
      description: PlaceholderAPI command
+     permission: placeholderapi.help
      aliases: [clipsplaceholderapi, papi, daddy]


### PR DESCRIPTION
This *should* fix 1.13.2 tab-complete list from showing commands that a player doesn't have permission to use. We could also default it to true and allow people to negate the permission to stop it from showing in tab-complete for people who shouldn't have access to it.