### PR TITLE
Load at startup

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ version: ${project.version}
 author: [extended_clip]
 description: ${project.description}
 api-version: 1.13
+load: STARTUP
 permissions:
     placeholderapi.*:
         description: ability to use all commands


### PR DESCRIPTION
By default plugins are loaded later. (post world) This complicates hooking into PlaceholderAPI from other plugins that load directly at startup as PlaceholderAPI isn't available yet at that point.

Besides that I feel like such a library should be available as early as possible as it itself doesn't depend on anything else but lots of other plugins and plugins depending on them might depend on it.