### PR TITLE
Adding issue templates and updating readme.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug Report  
+about: Found a bug with PlaceholderAPI? Report it through this form!
+
+---
+
+[New placeholders/plugin]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=feature_request.md
+[Request change]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request.md
+[Spigot page]: https://www.spigotmc.org/resources/6245/
+[Jenkins page]: http://ci.extendedclip.com/job/PlaceholderAPI/
+
+### Notes
+This template is for **reporting a bug** and not for requesting changes to the wiki!  
+If you want your placeholders added or updated, use the [New placeholders/plugin] or [Request change] template.
+
+Also make sure, that you use the latest version of PlaceholderAPI from either the [Spigot page] or the [Jenkins page].
+
+### Issue
+> What is the issue? Describe it like you would tell a friend.
+<!-- Please type below this like -->
+
+
+
+### Expected behaviour
+> What should PlaceholderAPI do?
+<!-- Please type below this like -->
+
+
+
+### Actual behaviour
+> What does PlaceholderAPI actually do?
+<!-- Please type below this like -->
+
+
+
+### How to reproduce
+> What steps did you made, to get this bug?
+<!-- Please type below this like -->
+1. 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,12 +8,14 @@ about: Found a bug with PlaceholderAPI? Report it through this form!
 [Request change]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request.md
 [Spigot page]: https://www.spigotmc.org/resources/6245/
 [Jenkins page]: http://ci.extendedclip.com/job/PlaceholderAPI/
+[issue]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
 
 ### Notes
 This template is for **reporting a bug** and not for requesting changes to the wiki!  
 If you want your placeholders added or updated, use the [New placeholders/plugin] or [Request change] template.
 
-Also make sure, that you use the latest version of PlaceholderAPI from either the [Spigot page] or the [Jenkins page].
+Also make sure, that you use the latest version of PlaceholderAPI from either the [Spigot page] or the [Jenkins page] and that your 
+issue isn't already listed in the [issue] page.
 
 ### Issue
 > What is the issue? Describe it like you would tell a friend.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,17 +20,14 @@ Also make sure, that you use the latest version of PlaceholderAPI from either th
 <!-- Please type below this like -->
 
 
-
 ### Expected behaviour
 > What should PlaceholderAPI do?
 <!-- Please type below this like -->
 
 
-
 ### Actual behaviour
 > What does PlaceholderAPI actually do?
 <!-- Please type below this like -->
-
 
 
 ### How to reproduce

--- a/.github/ISSUE_TEMPLATE/change_request.md
+++ b/.github/ISSUE_TEMPLATE/change_request.md
@@ -4,6 +4,18 @@ about: Request a update/change of a wiki-page
 
 ---
 
+[New placeholders/plugin]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=feature_request.md
+[Bug report]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md
+[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
+[wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
+
+### Notes
+This template is for **requesting changes to the wiki** and not for reporting bugs or requesting additions for the wiki!  
+If you want your placeholders added, use the [New placeholders/plugin] template.  
+For bug reports, use the [Bug report] template.
+
+Also make sure, that your requested change isn't already made in the [wiki] or listed in the [issues] page.
+
 ### Type
 > What kind of change is it? (Multiple selections possible)
 <!-- Please select the right one, by changing the [ ] to [x] -->
@@ -18,7 +30,7 @@ about: Request a update/change of a wiki-page
 
 
 ### What is the new value?
-> Placeholder(s) changed: Type what the old and the new placeholder(s) is/are.  
-> New Placeholder(s): Type the new placeholder(s).  
-> Plugin no longer supports PlaceholderAPI: Leave this blank.
+> **Placeholder(s) changed**: Type what the old and the new placeholder(s) is/are.  
+> **New Placeholder(s)**: Type the new placeholder(s).  
+> **Plugin no longer supports PlaceholderAPI**: Leave this blank.
 <!-- Please type below this line -->

--- a/.github/ISSUE_TEMPLATE/change_request.md
+++ b/.github/ISSUE_TEMPLATE/change_request.md
@@ -1,0 +1,24 @@
+---
+name: Request change  
+about: Request a update/change of a wiki-page
+
+---
+
+### Type
+> What kind of change is it? (Multiple selections possible)
+<!-- Please select the right one, by changing the [ ] to [x] -->
+
+- [ ] Placeholder(s) changed.
+- [ ] New placeholder(s).
+- [ ] Plugin no longer supports PlaceholderAPI and/or was deleted.
+
+### Plugin
+> What is the name of the plugin?
+<!-- Please type below this line -->
+
+
+### What is the new value?
+> Placeholder(s) changed: Type what the old and the new placeholder(s) is/are.  
+> New Placeholder(s): Type the new placeholder(s).  
+> Plugin no longer supports PlaceholderAPI: Leave this blank.
+<!-- Please type below this line -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,7 +11,7 @@ about: Do you have a plugin that supports and/or adds placeholders from/to Place
 
 ### Notes
 This template is for **requesting additions for the wiki** and not for reporting bugs or requesting changes for the wiki!  
-If you want changes made to the wiki, use the [Request change] template.  
+If you want changes being made to the wiki, use the [Request change] template.  
 For bug reports, use the [Bug report] template.
 
 Also make sure, that your requested placeholders/plugin isn't already added in the [wiki] or listed in the [issues] page.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,18 @@ about: Do you have a plugin that supports and/or adds placeholders from/to Place
 
 ---
 
+[Request change]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request.md
+[Bug report]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md
+[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
+[wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
+
+### Notes
+This template is for **requesting additions for the wiki** and not for reporting bugs or requesting changes for the wiki!  
+If you want changes made to the wiki, use the [Request change] template.  
+For bug reports, use the [Bug report] template.
+
+Also make sure, that your requested placeholders/plugin isn't already added in the [wiki] or listed in the [issues] page.
+
 ### Type
 > What kind of request is this? (Multiple selections possible)
 <!-- Select the right option by replacing [ ] with [x] -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: New placeholders/plugin
+about: Do you have a plugin that supports and/or adds placeholders from/to PlaceholderAPI and that isn't on the wiki? Use this template!
+
+---
+
+### Type
+> What kind of request is this? (Multiple selections possible)
+<!-- Select the right option by replacing [ ] with [x] -->
+<!-- For an update of an already listed plugin, use the "Request change" template -->
+
+- [ ] New expansion providing placeholders.
+- [ ] New plugin providing placeholders.
+- [ ] New plugin supporting PlaceholderAPI.
+
+### Plugin
+> What is the name of the plugin/expansion?
+> Provide also a link to it.
+<!-- Please type below this line -->
+
+### Placeholders/others
+> What are the new placeholders/Any additional info?
+<!-- Please type below this line -->

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ PlaceholderAPI has been downloaded over 100,000 times and has been used concurre
 
 ## Quick Links
 - [CI Server][ci]
-- [Expansions Website][expansions]
-- [Placeholder List][placeholder-list]
+- [Expansions cloud]
+- [Placeholder List]
 - [Spigot Page][spigot]
 - [Plugin Statistics][statistics]
 
@@ -29,9 +29,9 @@ PlaceholderAPI is licensed under the __GNU GPLv3__ license. Refer to the [LICENS
 <!-- Page Links - Placed here to be easier to change later on. -->
 
 [issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
-[discord]: https://discord.gg/7sndK3q
-[spigot]: https://www.spigotmc.org/resources/placeholderapi.6245/
+[discord]: https://helpch.at/discord
+[spigot]: https://www.spigotmc.org/resources/6245/
 [ci]: http://ci.extendedclip.com/job/PlaceholderAPI/
-[expansions]: https://api.extendedclip.com/all/
-[placeholder-list]: https://www.spigotmc.org/wiki/placeholderapi-placeholders/
+[Expansions cloud]: https://api.extendedclip.com/all/
+[placeholder list]: https://helpch.at/placeholders
 [statistics]: https://bstats.org/plugin/bukkit/PlaceholderAPI

--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
-[![PlaceholderAPI Logo](https://i.imgur.com/Ea4PURv.png)][spigot]
+[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
+[licenseImg]: https://img.shields.io/github/license/PlaceholderAPI/PlaceholderAPI.svg
+[license]: https://github.com/PlaceholderAPI/PlaceholderAPI/blob/master/LICENSE
 
-[![Build Status](http://ci.extendedclip.com/buildStatus/icon?job=PlaceholderAPI)][ci]
+[releaseImg]: https://img.shields.io/github/release/PlaceholderAPI/PlaceholderAPI.svg?label=github%20release
+[release]: https://github.com/PlaceholderAPI/PlaceholderAPI/releases/latest
+
+[discord]: https://helpch.at/discord
+[spigot]: https://www.spigotmc.org/resources/6245/
+[Expansions cloud]: https://api.extendedclip.com/home
+[placeholder list]: https://helpch.at/placeholders
+[statistics]: https://bstats.org/plugin/bukkit/PlaceholderAPI
+
+[ci]: http://ci.extendedclip.com/job/PlaceholderAPI/
+[ciImg]: http://ci.extendedclip.com/buildStatus/icon?job=PlaceholderAPI
+
+[APIversionImg]: https://img.shields.io/nexus/r/http/repo.extendedclip.com/me.clip/placeholderapi.svg?label=API-Version
+[logo]: https://i.imgur.com/Ea4PURv.png
+<!-- The stuff above isn't visible in the readme -->
+
+[![logo]][spigot]
+
+[![ciImg]][ci] [![releaseImg]][release] ![APIversionImg] [![licenseImg]][license]
 
 # Information 
 [PlaceholderAPI][spigot] is a plugin for Spigot servers that allows server owners to display information from various plugins with a uniform format. 
@@ -22,16 +42,3 @@ PlaceholderAPI has been downloaded over 100,000 times and has been used concurre
 - [Placeholder List]
 - [Spigot Page][spigot]
 - [Plugin Statistics][statistics]
-
-## License
-PlaceholderAPI is licensed under the __GNU GPLv3__ license. Refer to the [LICENSE](LICENSE) file for more information.
-
-<!-- Page Links - Placed here to be easier to change later on. -->
-
-[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
-[discord]: https://helpch.at/discord
-[spigot]: https://www.spigotmc.org/resources/6245/
-[ci]: http://ci.extendedclip.com/job/PlaceholderAPI/
-[Expansions cloud]: https://api.extendedclip.com/all/
-[placeholder list]: https://helpch.at/placeholders
-[statistics]: https://bstats.org/plugin/bukkit/PlaceholderAPI


### PR DESCRIPTION
[help-chat/PlaceholderAPI]: https://github.com/help-chat/PlaceholderAPI

This PR updates the README.md with new links and also adds the following issue templates to make the move of the wiki from [help-chat/PlaceholderAPI] to this repository complete:
- bug_report.md: Used for general bug reports of PlaceholderAPI.
- feature_request.md: Used for requesting the addition of new placeholders/a plugin to the wiki.
- change_request.md: Used for requesting a change to the wiki.