### PR TITLE
Adding getBoolean(boolean) method

### DIFF
--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
@@ -123,6 +123,7 @@ public class PlaceholderAPIPlugin extends JavaPlugin {
    */
   public static String getBoolean(boolean bol){
     return bol ? booleanTrue() : booleanFalse();
+  }
   
   public static Version getServerVersion() {
     return serverVersion != null ? serverVersion : getVersion();

--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
@@ -112,7 +112,18 @@ public class PlaceholderAPIPlugin extends JavaPlugin {
   public static String booleanFalse() {
     return booleanFalse != null ? booleanFalse : "false";
   }
-
+  
+  /**
+   * Returns {@link #booleanTrue() booleanTrue()} or {@link #booleanFalse() booleanFalse()} depending 
+   * on what the provided boolean is
+   *
+   * @param bol The boolean that determines which String is returned
+   *
+   * @return String value of true or false 
+   */
+  public static String getBoolean(boolean bol){
+    return bol ? booleanTrue() : booleanFalse();
+  
   public static Version getServerVersion() {
     return serverVersion != null ? serverVersion : getVersion();
   }


### PR DESCRIPTION
This adds `getBoolean(boolean bol)` which returns `booleanTrue` or `booleanFalse` depending on the provided boolean.

This can (and most likely will) improve the use of PlaceholderAPI and the `PlaceholderAPIPlugin` option to use the values provided in the config, so people don't have to do something like this:

```java
public String onRequest(OfflinePlayer player, String value){
    
    if(value.equalsIgnoreCase("is_online"){
        return myPlugin.playerIsOnline(player) ? PlaceholderAPIPlugin.booleanTrue() : PlaceholderAPIPlugin.booleanFalse();
    }
}
```

This closes #83 
I made this through GitHub itself so I couldn't check if what I made is right and corrections are welcome.