### PR TITLE
Removed unnecessary alias

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -40,4 +40,4 @@ permissions:
 commands:
    placeholderapi:
      description: PlaceholderAPI command
-     aliases: [clipsplaceholderapi, papi, daddy]
+     aliases: [clipsplaceholderapi, papi]


### PR DESCRIPTION
I would like @extendedclip to review this PR. 

If users want to use the alias "daddy" they should open the jar, and add it themselves in the plugin.yml.
I highly doubt  anyone uses this alias and it's just useless.

@Andre601 Papi only means daddy in italian, not in german, but that still is irrelevant as this alias is just plain stupid. This abbreviation means daddy in one language out of thousands of languages. Papi is an abbreviation,  daddy is not.