### PR TITLE
Fixing broken link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ about: Report bugs of PlaceholderAPI with this template
 [Request change (PlaceholderAPI)]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request_placeholderapi.md
 [Spigot]: https://www.spigotmc.org/resources/6245/
 [Jenkins]: http://ci.extendedclip.com/job/PlaceholderAPI/
-[issue]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
+[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
 
 ## Please read
 This template is only for reporting bugs of PlaceholderAPI!  


### PR DESCRIPTION
[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md

## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Other: Fix of issue template(s) <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.
<!-- Please type below this line -->
This PR fixes the issue template, where the link for the issue page (`[issue]`) was wrong and not working