### PR TITLE
Fixes ecloud placeholders command

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/ExpansionCloudCommands.java
+++ b/src/main/java/me/clip/placeholderapi/commands/ExpansionCloudCommands.java
@@ -238,7 +238,11 @@ public class ExpansionCloudCommands implements CommandExecutor {
         } else {
           message.then(color(placeholders.get(i) + "&b, &f"));
         }
-        message.tooltip(PlaceholderAPI.setPlaceholders(p, placeholders.get(i)));
+        try {
+          message.tooltip(PlaceholderAPI.setPlaceholders(p, placeholders.get(i)));
+        } catch (Exception e) {
+
+        }
       }
 
       message.send(p);

--- a/src/main/java/me/clip/placeholderapi/expansion/ExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/ExpansionManager.java
@@ -151,7 +151,12 @@ public final class ExpansionManager {
     for (Class<?> klass : subs) {
       PlaceholderExpansion ex = createInstance(klass);
       if (ex != null) {
-        registerExpansion(ex);
+        try {
+          registerExpansion(ex);
+        } catch (Exception e) {
+          plugin.getLogger().info("Couldn't register " + ex.getIdentifier() + " expansion");
+          e.printStackTrace();
+        }
       }
     }
   }


### PR DESCRIPTION
[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md

## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.

Fixes #197 (`/papi ecloud placeholders <Expansion>` command).
The command parses the placeholders, some placeholders require (specific) arguments, and when parsing the placeholder without the required argument, the plugin throws an error in the console and the command fails.