### PR TITLE
Added permissions to base command and help command

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/PlaceholderAPICommands.java
+++ b/src/main/java/me/clip/placeholderapi/commands/PlaceholderAPICommands.java
@@ -48,7 +48,10 @@ public class PlaceholderAPICommands implements CommandExecutor {
   @Override
   public boolean onCommand(CommandSender s, Command c, String label, String[] args) {
     if (args.length == 0) {
-
+      if (!s.hasPermission("placeholderapi.help")) {
+        Msg.msg(s, "&cYou don't have permission to do that!");
+        return true;
+      }
       Msg.msg(s, "PlaceholderAPI &7version &b&o" + plugin.getDescription().getVersion(),
           "&fCreated by&7: &b" + plugin.getDescription().getAuthors(),
               "&fPapi commands: &b/papi help",
@@ -57,7 +60,10 @@ public class PlaceholderAPICommands implements CommandExecutor {
       return true;
     } else {
       if (args[0].equalsIgnoreCase("help")) {
-
+        if (!s.hasPermission("placeholderapi.help")) {
+          Msg.msg(s, "&cYou don't have permission to do that!");
+          return true;
+        }
         Msg.msg(s, "PlaceholderAPI &aHelp &e(&f" + plugin.getDescription().getVersion() + "&e)",
             "&b/papi",
             "&fView plugin info/version info",

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -40,3 +40,4 @@ commands:
    placeholderapi:
      description: PlaceholderAPI command
      aliases: [papi]
+     permission: placeholderapi.help

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,6 +18,7 @@ permissions:
             placeholderapi.parse: true
             placeholderapi.register: true
             placeholderapi.updatenotify: true
+            placeholderapi.help: true
     placeholderapi.list:
         description: ability to use the list command
         default: op
@@ -35,6 +36,9 @@ permissions:
         default: op
     placeholderapi.updatenotify:
         description: notifies you when there is a PAPI update
+        default: op
+    placeholderapi.help:
+        description: ability to use the help command
         default: op
 commands:
    placeholderapi:


### PR DESCRIPTION
[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md

## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.
<!-- Please type below this line -->
Added permission "placeholderapi.help" to both the base command(`/placeholderapi`) and the help command(`/placeholderapi help`) and in the plugins.yml so normal players will not see the placeholderapi command in the command suggestion list