### PR TITLE
Add issue template config for custom template selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,20 +21,20 @@ Please also make sure that you use the [latest release][Spigot] or the latest [d
 
 ### Issue
 > What is the issue? Describe it like you would tell a friend.
-<!-- Please type below this like -->
+<!-- Please write below this line to prevent formatting issues -->
 
 
 ### Expected behaviour
 > What should PlaceholderAPI do?
-<!-- Please type below this like -->
+<!-- Please write below this line to prevent formatting issues -->
 
 
 ### Actual behaviour
 > What does PlaceholderAPI actually do?
-<!-- Please type below this like -->
+<!-- Please write below this line to prevent formatting issues -->
 
 
 ### How to reproduce
 > What steps did you made, to get this bug?
-<!-- Please type below this like -->
+<!-- Please write below this line to prevent formatting issues -->
 1. 

--- a/.github/ISSUE_TEMPLATE/change_request_placeholderapi.md
+++ b/.github/ISSUE_TEMPLATE/change_request_placeholderapi.md
@@ -35,4 +35,4 @@ Changes to code that will affect the end-user (breaks stuff).
 ### Info
 > What is the change?  
 > Please provide as much information (including links, images and code-snippeds) as possible.
-<!-- Please type below this line -->
+<!-- Please write below this line to prevent formatting issues -->

--- a/.github/ISSUE_TEMPLATE/change_request_wiki.md
+++ b/.github/ISSUE_TEMPLATE/change_request_wiki.md
@@ -31,4 +31,4 @@ An already listed expansion/plugin has new placeholders or old ones have changed
 ### Info
 > Please provide any information that is useful including links and images.  
 > For plugins/expansion providing new placeholders or updating old ones, provide the placeholders (that have changed)
-<!-- Please type below this line -->
+<!-- Please write below this line to prevent formatting issues -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: HelpChat Discord
+    url: https://discord.gg/helpchat
+  - name: Wiki
+    url: https://wiki.helpch.at/
+  - name: Paste for errors and config files
+    url: https://paste.helpch.at

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://discord.gg/helpchat
     about: Please join our Discord for faster support.
   - name: Wiki
-    url: https://wiki.helpch.at/
-    about: Check out our wiki about various plugins including PlaceholderAPI.
+    url: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
+    about: The Wiki of PlaceholderAPI.
   - name: Hastebin
     url: https://paste.helpch.at
     about: Use our Hastebin-site for sharing errors and configuration files.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: HelpChat Discord
     url: https://discord.gg/helpchat
+    about: Please join our Discord for faster support.
   - name: Wiki
     url: https://wiki.helpch.at/
-  - name: Paste for errors and config files
+    about: Check out our wiki about various plugins including PlaceholderAPI.
+  - name: Hastebin
     url: https://paste.helpch.at
+    about: Use our Hastebin-site for sharing errors and configuration files.


### PR DESCRIPTION
[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md

## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Other: New config.yml for issue templates <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.
<!-- Please type below this line -->
This Draft PR adds a `config.yml` to the `.github/ISSUE_TEMPLATE` section, which allows customisation of the template selection, including the addition of external links to sites like wikis, documentation, etc.

I so far implemented the following:
- Disabling option to create blank issues (Can be enabled if requested)
- Adding links to the wiki, paste-site and Discord.

Any additional ideas, links, etc. can be suggested and I'll add them.
If everything is okay, will I make this PR mergable.

Example of new template selection:
![image](https://user-images.githubusercontent.com/11576465/77836193-51b17f80-7154-11ea-8abc-9e2ded6c1aed.png)
