### PR TITLE
Adds default_placeholder_pattern config option

### DIFF
--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPI.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPI.java
@@ -41,7 +41,7 @@ import static me.clip.placeholderapi.util.Msg.color;
 
 public class PlaceholderAPI {
   
-  private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("[%]([^%]+)[%]");
+  private static final Pattern PERCENT_SIGN_PLACEHOLDER_PATTERN = Pattern.compile("[%]([^%]+)[%]");
   private static final Pattern BRACKET_PLACEHOLDER_PATTERN = Pattern.compile("[{]([^{}]+)[}]");
   private static final Pattern RELATIONAL_PLACEHOLDER_PATTERN = Pattern.compile("[%](rel_)([^%]+)[%]");
   private static final Map<String, PlaceholderHook> placeholders = new HashMap<>();
@@ -121,13 +121,23 @@ public class PlaceholderAPI {
   }
   
   /**
-   * Check if a String contains any PlaceholderAPI placeholders ({@literal %<identifier>_<params>%}).
+   * Check if a String contains any PlaceholderAPI default placeholders ({@link PlaceholderAPIPlugin#getDefaultPlaceholderPattern}).
    *
    * @param text String to check
    * @return true if String contains any registered placeholder identifiers, false otherwise
    */
   public static boolean containsPlaceholders(String text) {
-    return text != null && PLACEHOLDER_PATTERN.matcher(text).find();
+    return text != null && PlaceholderAPIPlugin.getDefaultPlaceholderPattern().matcher(text).find();
+  }
+
+  /**
+   * Check if a String contains any PlaceholderAPI percent sign placeholders ({@literal %<identifier>_<params>%}).
+   *
+   * @param text String to check
+   * @return true if String contains any registered placeholder identifiers, false otherwise
+   */
+  public static boolean containsPercentSignPlaceholders(String text) {
+    return text != null && PERCENT_SIGN_PLACEHOLDER_PATTERN.matcher(text).find();
   }
   
   /**
@@ -167,19 +177,19 @@ public class PlaceholderAPI {
   
   /**
    * Translates all placeholders into their corresponding values.
-   * <br>The pattern of a valid placeholder is {@literal %<identifier>_<params>%}.
+   * <br>The pattern of a valid placeholder is {@link PlaceholderAPIPlugin#getDefaultPlaceholderPattern}.
    *
    * @param player Player to parse the placeholders against
    * @param text List of Strings to set the placeholder values in
    * @return String containing all translated placeholders
    */
   public static List<String> setPlaceholders(OfflinePlayer player, List<String> text) {
-    return setPlaceholders(player, text, PLACEHOLDER_PATTERN, true);
+    return setPlaceholders(player, text, PlaceholderAPIPlugin.getDefaultPlaceholderPattern(), true);
   }
   
   /**
    * Translates all placeholders into their corresponding values.
-   * <br>The pattern of a valid placeholder is {@literal %<identifier>_<params>%}.
+   * <br>The pattern of a valid placeholder is {@link PlaceholderAPIPlugin#getDefaultPlaceholderPattern}.
    *
    * @param player Player to parse the placeholders against
    * @param text List of Strings to set the placeholder values in
@@ -187,7 +197,7 @@ public class PlaceholderAPI {
    * @return String containing all translated placeholders
    */
   public static List<String> setPlaceholders(OfflinePlayer player, List<String> text, boolean colorize) {
-    return setPlaceholders(player, text, PLACEHOLDER_PATTERN, colorize);
+    return setPlaceholders(player, text, PlaceholderAPIPlugin.getDefaultPlaceholderPattern(), colorize);
   }
   
   /**
@@ -251,19 +261,19 @@ public class PlaceholderAPI {
   
   /**
    * Translates all placeholders into their corresponding values.
-   * <br>The pattern of a valid placeholder is {@literal %<identifier>_<params>%}.
+   * <br>The pattern of a valid placeholder is {@link PlaceholderAPIPlugin#getDefaultPlaceholderPattern}.
    *
    * @param player Player to parse the placeholders against
    * @param text Text to set the placeholder values in
    * @return String containing all translated placeholders
    */
   public static String setPlaceholders(OfflinePlayer player, String text) {
-    return setPlaceholders(player, text, PLACEHOLDER_PATTERN);
+    return setPlaceholders(player, text, PlaceholderAPIPlugin.getDefaultPlaceholderPattern());
   }
   
   /**
    * Translates all placeholders into their corresponding values.
-   * <br>The pattern of a valid placeholder is {@literal %<identifier>_<params>%}.
+   * <br>The pattern of a valid placeholder is {@link PlaceholderAPIPlugin#getDefaultPlaceholderPattern}.
    *
    * @param player Player to parse the placeholder against
    * @param text Text to parse the placeholders in
@@ -271,7 +281,7 @@ public class PlaceholderAPI {
    * @return The text containing the parsed placeholders
    */
   public static String setPlaceholders(OfflinePlayer player, String text, boolean colorize) {
-    return setPlaceholders(player, text, PLACEHOLDER_PATTERN, colorize);
+    return setPlaceholders(player, text, PlaceholderAPIPlugin.getDefaultPlaceholderPattern(), colorize);
   }
   
   /**
@@ -477,12 +487,21 @@ public class PlaceholderAPI {
   /**
    * Gets the placeholder pattern for the default placeholders.
    *
-   * @return The pattern for {@literal %<identifier>_<params>%}
+   * @return The pattern for {@link PlaceholderAPIPlugin#getDefaultPlaceholderPattern}
    */
   public static Pattern getPlaceholderPattern() {
-    return PLACEHOLDER_PATTERN;
+    return PlaceholderAPIPlugin.getDefaultPlaceholderPattern();
   }
-  
+
+  /**
+   * Gets the placeholder pattern for the default placeholders.
+   *
+   * @return The pattern for {@literal %<identifier>_<params>%}
+   */
+  public static Pattern getPercentSignPlaceholderPattern() {
+    return PERCENT_SIGN_PLACEHOLDER_PATTERN;
+  }
+
   /**
    * Gets the placeholder pattern for the bracket placeholders.
    *
@@ -522,19 +541,19 @@ public class PlaceholderAPI {
   }
   
   public static String setPlaceholders(Player player, String text) {
-    return setPlaceholders(player, text, PLACEHOLDER_PATTERN, true);
+    return setPlaceholders(player, text, PlaceholderAPIPlugin.getDefaultPlaceholderPattern(), true);
   }
   
   public static String setPlaceholders(Player player, String text, boolean colorize) {
-    return setPlaceholders(player, text, PLACEHOLDER_PATTERN, colorize);
+    return setPlaceholders(player, text, PlaceholderAPIPlugin.getDefaultPlaceholderPattern(), colorize);
   }
   
   public static List<String> setPlaceholders(Player player, List<String> text) {
-    return setPlaceholders(player, text, PLACEHOLDER_PATTERN, true);
+    return setPlaceholders(player, text, PlaceholderAPIPlugin.getDefaultPlaceholderPattern(), true);
   }
   
   public static List<String> setPlaceholders(Player player, List<String> text, boolean colorize) {
-    return setPlaceholders(player, text, PLACEHOLDER_PATTERN, colorize);
+    return setPlaceholders(player, text, PlaceholderAPIPlugin.getDefaultPlaceholderPattern(), colorize);
   }
   
   public static String setBracketPlaceholders(Player player, String text) {
@@ -551,5 +570,71 @@ public class PlaceholderAPI {
   
   public static List<String> setBracketPlaceholders(Player player, List<String> text, boolean colorize) {
     return setPlaceholders(player, text, BRACKET_PLACEHOLDER_PATTERN, colorize);
+  }
+
+  /**
+   * Translates all placeholders into their corresponding values.
+   * <br>The pattern of a valid placeholder is {@literal %<identifier>_<params>%}.
+   *
+   * @param player Player to parse the placeholders against
+   * @param text List of Strings to set the placeholder values in
+   * @return String containing all translated placeholders
+   */
+  public static List<String> setPercentSignPlaceholders(OfflinePlayer player, List<String> text) {
+    return setPlaceholders(player, text, PERCENT_SIGN_PLACEHOLDER_PATTERN, true);
+  }
+
+  /**
+   * Translates all placeholders into their corresponding values.
+   * <br>The pattern of a valid placeholder is {@literal %<identifier>_<params>%}.
+   *
+   * @param player Player to parse the placeholders against
+   * @param text List of Strings to set the placeholder values in
+   * @param colorize If color codes (&[0-1a-fk-o]) should be translated
+   * @return String containing all translated placeholders
+   */
+  public static List<String> setPercentSignPlaceholders(OfflinePlayer player, List<String> text, boolean colorize) {
+    return setPlaceholders(player, text, PERCENT_SIGN_PLACEHOLDER_PATTERN, colorize);
+  }
+
+  /**
+   * Translates all placeholders into their corresponding values.
+   * <br>The pattern of a valid placeholder is {@literal %<identifier>_<params>%}.
+   *
+   * @param player Player to parse the placeholders against
+   * @param text Text to set the placeholder values in
+   * @return String containing all translated placeholders
+   */
+  public static String setPercentSignPlaceholders(OfflinePlayer player, String text) {
+    return setPlaceholders(player, text, PERCENT_SIGN_PLACEHOLDER_PATTERN);
+  }
+
+  /**
+   * Translates all placeholders into their corresponding values.
+   * <br>The pattern of a valid placeholder is {@literal %<identifier>_<params>%}.
+   *
+   * @param player Player to parse the placeholder against
+   * @param text Text to parse the placeholders in
+   * @param colorize If color codes (&[0-1a-fk-o]) should be translated
+   * @return The text containing the parsed placeholders
+   */
+  public static String setPercentSignPlaceholders(OfflinePlayer player, String text, boolean colorize) {
+    return setPlaceholders(player, text, PERCENT_SIGN_PLACEHOLDER_PATTERN, colorize);
+  }
+
+  public static String setPercentSignPlaceholders(Player player, String text) {
+    return setPlaceholders(player, text, PERCENT_SIGN_PLACEHOLDER_PATTERN, true);
+  }
+
+  public static String setPercentSignPlaceholders(Player player, String text, boolean colorize) {
+    return setPlaceholders(player, text, PERCENT_SIGN_PLACEHOLDER_PATTERN, colorize);
+  }
+
+  public static List<String> setPercentSignPlaceholders(Player player, List<String> text) {
+    return setPlaceholders(player, text, PERCENT_SIGN_PLACEHOLDER_PATTERN, true);
+  }
+
+  public static List<String> setPercentSignPlaceholders(Player player, List<String> text, boolean colorize) {
+    return setPlaceholders(player, text, PERCENT_SIGN_PLACEHOLDER_PATTERN, colorize);
   }
 }

--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
@@ -39,6 +39,7 @@ import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 
 /**
@@ -53,6 +54,7 @@ public class PlaceholderAPIPlugin extends JavaPlugin {
   private static String booleanTrue;
   private static String booleanFalse;
   private static Version serverVersion;
+  private static Pattern defaultPlaceholderPattern;
   private PlaceholderAPIConfig config;
   private ExpansionManager expansionManager;
   private ExpansionCloudManager expansionCloud;
@@ -96,8 +98,7 @@ public class PlaceholderAPIPlugin extends JavaPlugin {
    * @return date format
    */
   public static SimpleDateFormat getDateFormat() {
-    return dateFormat != null ? dateFormat : new SimpleDateFormat(
-        "MM/dd/yy HH:mm:ss");
+    return dateFormat != null ? dateFormat : new SimpleDateFormat("MM/dd/yy HH:mm:ss");
   }
 
   /**
@@ -120,6 +121,17 @@ public class PlaceholderAPIPlugin extends JavaPlugin {
 
   public static Version getServerVersion() {
     return serverVersion != null ? serverVersion : getVersion();
+  }
+
+  /**
+   * Get the configurable {@link Pattern} object that is used to parse placeholders when using {@link PlaceholderAPI#setPlaceholders}
+   *
+   * @return string value of false
+   */
+  public static Pattern getDefaultPlaceholderPattern() {
+    if (defaultPlaceholderPattern != null) return defaultPlaceholderPattern;
+    defaultPlaceholderPattern = Pattern.compile("[%]([^%]+)[%]");
+    return defaultPlaceholderPattern;
   }
 
   @Override
@@ -236,6 +248,12 @@ public class PlaceholderAPIPlugin extends JavaPlugin {
       dateFormat = new SimpleDateFormat(config.dateFormat());
     } catch (Exception e) {
       dateFormat = new SimpleDateFormat("MM/dd/yy HH:mm:ss");
+    }
+
+    try {
+      defaultPlaceholderPattern = Pattern.compile(config.defaultPlaceholderPattern());
+    } catch (Exception e) {
+      defaultPlaceholderPattern = Pattern.compile("[%]([^%]+)[%]");
     }
   }
 

--- a/src/main/java/me/clip/placeholderapi/configuration/PlaceholderAPIConfig.java
+++ b/src/main/java/me/clip/placeholderapi/configuration/PlaceholderAPIConfig.java
@@ -67,4 +67,6 @@ public class PlaceholderAPIConfig {
   public String dateFormat() {
     return plugin.getConfig().getString("date_format");
   }
+
+  public String defaultPlaceholderPattern() { return plugin.getConfig().getString("default_placeholder_pattern"); }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,4 +15,5 @@ boolean:
   'true': 'yes'
   'false': 'no'
 date_format: MM/dd/yy HH:mm:ss
+default_placeholder_pattern: '[%]([^%]+)[%]'
 debug: false


### PR DESCRIPTION
[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md

## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.
<!-- Please type below this line -->

closes #297

Adds default_placeholder_pattern in config. This pattern will now be used in functions that previously used PLACEHOLDER_PATTERN. By default it is set to the same pattern as PLACEHOLDER_PATTERN to maintain backwards compatibility.

PLACEHOLDER_PATTERN has been renamed to PERCENT_SIGN_PLACEHOLDER_PATTERN, the functions using it previously were recreated with appropriate names.