### PR TITLE
Added "Installed expansions" section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,3 +38,7 @@ Please also make sure that you use the [latest release][Spigot] or the latest [d
 > What steps did you made, to get this bug?
 <!-- Please write below this line to prevent formatting issues -->
 1. 
+
+### Installed expansions
+> Please use all expansions that are listed when running `/papi list`
+<!-- Please write below this line to prevent formatting issues -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,5 +40,5 @@ Please also make sure that you use the [latest release][Spigot] or the latest [d
 1. 
 
 ### Installed expansions
-> Please use all expansions that are listed when running `/papi list`
+> Please list all expansions that are displayed when running `/papi list`
 <!-- Please write below this line to prevent formatting issues -->


### PR DESCRIPTION
[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md

## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Other: Issue templates <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.
<!-- Please type below this line -->
I think it would be beneficial to have a `Installed expansions` section in the bug report template to know what expansions are installed that might be the cause of an issue.