### PR TITLE
Fix missing line break in expansion list command.

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionList.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionList.java
@@ -143,7 +143,8 @@ public final class CommandECloudExpansionList extends PlaceholderCommand
 			int index = ((page - 1) * PAGE_SIZE) + 1;
 			for (final CloudExpansion expansion : values)
 			{
-				builder.append("&8")
+				builder.append("\n")
+				           .append("&8")
 					   .append(index++)
 					   .append(". ")
 					   .append((expansion.shouldUpdate() ? "&6" : expansion.hasExpansion() ? "&a" : "&7"))


### PR DESCRIPTION
[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md

## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.
<!-- Please type below this line -->
Fixes the issue described [here](https://github.com/PlaceholderAPI/PlaceholderAPI/issues/367#issuecomment-663632503) where the list command doesn't put each expansion on a new list.
I would appreciate if this can be checked to see if this is alright.