### PR TITLE
Move links down in the templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,12 +4,6 @@ about: Report bugs of PlaceholderAPI with this template
 
 ---
 
-[Request change (Wiki)]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request_wiki.md
-[Request change (PlaceholderAPI)]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request_placeholderapi.md
-[Spigot]: https://www.spigotmc.org/resources/6245/
-[Jenkins]: http://ci.extendedclip.com/job/PlaceholderAPI/
-[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
-
 ## Please read
 This template is only for reporting bugs of PlaceholderAPI!  
 If you want to request changes to the code of PlaceholderAPI, use the [Request change (PlaceholderAPI)] template.  
@@ -42,3 +36,13 @@ Please also make sure that you use the [latest release][Spigot] or the latest [d
 ### Installed expansions
 > Please list all expansions that are displayed when running `/papi list`
 <!-- Please write below this line to prevent formatting issues -->
+
+
+
+<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
+
+[Request change (Wiki)]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request_wiki.md
+[Request change (PlaceholderAPI)]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request_placeholderapi.md
+[Spigot]: https://www.spigotmc.org/resources/6245/
+[Jenkins]: http://ci.extendedclip.com/job/PlaceholderAPI/
+[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues

--- a/.github/ISSUE_TEMPLATE/change_request_placeholderapi.md
+++ b/.github/ISSUE_TEMPLATE/change_request_placeholderapi.md
@@ -4,12 +4,6 @@ about: Request a update/change of the PlaceholderAPI-code
 
 ---
 
-[Request change (Wiki)]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request_wiki.md
-[Bug report]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md
-[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
-[wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
-[Pull Requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
-
 ## Please read
 This template is only for requesting new functions to be added to PlaceholderAPI or for old one to be changed!  
 Please use the [Request change (Wiki)] template to ask for additions/changes to the wiki.  
@@ -36,3 +30,13 @@ Changes to code that will affect the end-user (breaks stuff).
 > What is the change?  
 > Please provide as much information (including links, images and code-snippeds) as possible.
 <!-- Please write below this line to prevent formatting issues -->
+
+
+
+<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
+
+[Request change (Wiki)]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request_wiki.md
+[Bug report]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md
+[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
+[wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
+[Pull Requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls

--- a/.github/ISSUE_TEMPLATE/change_request_wiki.md
+++ b/.github/ISSUE_TEMPLATE/change_request_wiki.md
@@ -4,11 +4,6 @@ about: Request a update/change of a wiki-page
 
 ---
 
-[Request change (PlaceholderAPI)]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request_placeholderapi.md
-[Bug report]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md
-[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
-[wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
-
 ## Please read
 This template is only for requesting new information to be added to the wiki or for updating of already existing information!  
 Please use the [Request change (PlaceholderAPI)] template to ask for additions/changes to the plugin PlaceholderAPI.  
@@ -32,3 +27,12 @@ An already listed expansion/plugin has new placeholders or old ones have changed
 > Please provide any information that is useful including links and images.  
 > For plugins/expansion providing new placeholders or updating old ones, provide the placeholders (that have changed)
 <!-- Please write below this line to prevent formatting issues -->
+
+
+
+<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
+
+[Request change (PlaceholderAPI)]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=change_request_placeholderapi.md
+[Bug report]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md
+[issues]: https://github.com/PlaceholderAPI/PlaceholderAPI/issues
+[wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,3 @@
-[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
-[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md
-
 ## Please read
 Please make sure you checked the following:
 - You checked the [Pull requests] page for any upcoming changes.
@@ -13,8 +10,16 @@ Please make sure you checked the following:
 -->
 - [ ] Internal change (Doesn't affect end-user).
 - [ ] External change (Does affect end-user).
+- [ ] Wiki (Changes towards the [Wiki]).
 - [ ] Other: __________ <!-- Use this if none of the above matches your request -->
 
 ### Description
 > Provide additional information if needed.
 <!-- Please type below this line -->
+
+
+<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
+
+[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
+[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md
+[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki


### PR DESCRIPTION
[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md

## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Other: Issue templates <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.
<!-- Please type below this line -->
This PR moves the links in the issue templates to the bottom. Main reason is, to make it more readable in the papi-updates channel on the Discord server.