### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+#
+# Assigns extendedclip and PiggyPiglet for any PR unless a check below matches.
+#
+*      @extendedclip @PiggyPiglet
+
+#
+# Assigns Andre601 to any PR that targets the wiki folder.
+#
+/wiki/ @Andre601


### PR DESCRIPTION
## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [x] Other: Repository <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.
<!-- Please type below this line -->
This adds a CODEOWNERS file, which will make GitHub auto-assign users as reviewers to any PR that targets the given folders/files.

This PR - when merged - should also be added to the other main branches (`docs/wiki` and `develop` if created) to apply to those too.

Right now does the file assign the following people:

- @extendedclip and @PiggyPiglet for any PR
- @Andre601 for any PR targeting the `wiki` folder (This should override the above case according to the GitHub docs)

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->

[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
