### PR TITLE
Improve dump command and fix indents for GitHub

### DIFF
--- a/src/main/java/me/clip/placeholderapi/PlaceholderHook.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderHook.java
@@ -35,25 +35,25 @@ import org.jetbrains.annotations.Nullable;
 public abstract class PlaceholderHook
 {
 
-	@Nullable
-	public String onRequest(@Nullable final OfflinePlayer player, @NotNull final String params)
-	{
-		if (player != null && player.isOnline())
-		{
-			return onPlaceholderRequest((Player) player, params);
-		}
+  @Nullable
+  public String onRequest(@Nullable final OfflinePlayer player, @NotNull final String params)
+  {
+    if (player != null && player.isOnline())
+    {
+      return onPlaceholderRequest((Player) player, params);
+    }
 
-		return onPlaceholderRequest(null, params);
-	}
+    return onPlaceholderRequest(null, params);
+  }
 
-	/**
-	 * @deprecated This method will be completely removed, please use {@link me.clip.placeholderapi.expansion.PlaceholderExpansion#onRequest(OfflinePlayer, String)}
-	 */
-	@Nullable
-	@Deprecated
-	public String onPlaceholderRequest(@Nullable final Player player, @NotNull final String params)
-	{
-		return null;
-	}
+  /**
+   * @deprecated This method will be completely removed, please use {@link me.clip.placeholderapi.expansion.PlaceholderExpansion#onRequest(OfflinePlayer, String)}
+   */
+  @Nullable
+  @Deprecated
+  public String onPlaceholderRequest(@Nullable final Player player, @NotNull final String params)
+  {
+    return null;
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/PlaceholderCommand.java
+++ b/src/main/java/me/clip/placeholderapi/commands/PlaceholderCommand.java
@@ -35,84 +35,84 @@ import java.util.stream.Stream;
 public abstract class PlaceholderCommand
 {
 
-	@NotNull
-	private final String      label;
-	@NotNull
-	private final Set<String> alias;
+  @NotNull
+  private final String      label;
+  @NotNull
+  private final Set<String> alias;
 
-	@Nullable
-	private String permission;
-
-
-	protected PlaceholderCommand(@NotNull final String label, @NotNull final String... alias)
-	{
-		this.label = label;
-		this.alias = Sets.newHashSet(alias);
-
-		setPermission("placeholderapi." + label);
-	}
+  @Nullable
+  private String permission;
 
 
-	@NotNull
-	public final String getLabel()
-	{
-		return label;
-	}
+  protected PlaceholderCommand(@NotNull final String label, @NotNull final String... alias)
+  {
+    this.label = label;
+    this.alias = Sets.newHashSet(alias);
 
-	@NotNull
-	@Unmodifiable
-	public final Set<String> getAlias()
-	{
-		return ImmutableSet.copyOf(alias);
-	}
-
-	@NotNull
-	@Unmodifiable
-	public final Set<String> getLabels()
-	{
-		return ImmutableSet.<String>builder().add(label).addAll(alias).build();
-	}
+    setPermission("placeholderapi." + label);
+  }
 
 
-	@Nullable
-	public final String getPermission()
-	{
-		return permission;
-	}
+  @NotNull
+  public final String getLabel()
+  {
+    return label;
+  }
 
-	public void setPermission(@NotNull final String permission)
-	{
-		this.permission = permission;
-	}
+  @NotNull
+  @Unmodifiable
+  public final Set<String> getAlias()
+  {
+    return ImmutableSet.copyOf(alias);
+  }
 
-
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-
-	}
-
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-
-	}
+  @NotNull
+  @Unmodifiable
+  public final Set<String> getLabels()
+  {
+    return ImmutableSet.<String>builder().add(label).addAll(alias).build();
+  }
 
 
-	@NotNull
-	public static Stream<PlaceholderCommand> filterByPermission(@NotNull final CommandSender sender, @NotNull final Stream<PlaceholderCommand> commands)
-	{
-		return commands.filter(target -> target.getPermission() == null || sender.hasPermission(target.getPermission()));
-	}
+  @Nullable
+  public final String getPermission()
+  {
+    return permission;
+  }
 
-	public static void suggestByParameter(@NotNull final Stream<String> possible, @NotNull final List<String> suggestions, @Nullable final String parameter)
-	{
-		if (parameter == null)
-		{
-			possible.forEach(suggestions::add);
-		}
-		else
-		{
-			possible.filter(suggestion -> suggestion.toLowerCase().startsWith(parameter.toLowerCase())).forEach(suggestions::add);
-		}
-	}
+  public void setPermission(@NotNull final String permission)
+  {
+    this.permission = permission;
+  }
+
+
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+
+  }
+
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+
+  }
+
+
+  @NotNull
+  public static Stream<PlaceholderCommand> filterByPermission(@NotNull final CommandSender sender, @NotNull final Stream<PlaceholderCommand> commands)
+  {
+    return commands.filter(target -> target.getPermission() == null || sender.hasPermission(target.getPermission()));
+  }
+
+  public static void suggestByParameter(@NotNull final Stream<String> possible, @NotNull final List<String> suggestions, @Nullable final String parameter)
+  {
+    if (parameter == null)
+    {
+      possible.forEach(suggestions::add);
+    }
+    else
+    {
+      possible.filter(suggestion -> suggestion.toLowerCase().startsWith(parameter.toLowerCase())).forEach(suggestions::add);
+    }
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/PlaceholderCommandRouter.java
+++ b/src/main/java/me/clip/placeholderapi/commands/PlaceholderCommandRouter.java
@@ -47,97 +47,97 @@ import java.util.stream.Stream;
 public final class PlaceholderCommandRouter implements CommandExecutor, TabCompleter
 {
 
-	@Unmodifiable
-	private static final List<PlaceholderCommand> COMMANDS = ImmutableList.of(new CommandHelp(),
-																			  new CommandInfo(),
-																			  new CommandList(),
-																			  new CommandDump(),
-																			  new CommandECloud(),
-																			  new CommandParse(),
-																			  new CommandReload(),
-																			  new CommandVersion(),
-																			  new CommandExpansionRegister(),
-																			  new CommandExpansionUnregister());
+  @Unmodifiable
+  private static final List<PlaceholderCommand> COMMANDS = ImmutableList.of(new CommandHelp(),
+                                        new CommandInfo(),
+                                        new CommandList(),
+                                        new CommandDump(),
+                                        new CommandECloud(),
+                                        new CommandParse(),
+                                        new CommandReload(),
+                                        new CommandVersion(),
+                                        new CommandExpansionRegister(),
+                                        new CommandExpansionUnregister());
 
 
-	@NotNull
-	private final PlaceholderAPIPlugin            plugin;
-	@NotNull
-	@Unmodifiable
-	private final Map<String, PlaceholderCommand> commands;
+  @NotNull
+  private final PlaceholderAPIPlugin            plugin;
+  @NotNull
+  @Unmodifiable
+  private final Map<String, PlaceholderCommand> commands;
 
 
-	public PlaceholderCommandRouter(@NotNull final PlaceholderAPIPlugin plugin)
-	{
-		this.plugin = plugin;
+  public PlaceholderCommandRouter(@NotNull final PlaceholderAPIPlugin plugin)
+  {
+    this.plugin = plugin;
 
-		final ImmutableMap.Builder<String, PlaceholderCommand> commands = ImmutableMap.builder();
+    final ImmutableMap.Builder<String, PlaceholderCommand> commands = ImmutableMap.builder();
 
-		for (final PlaceholderCommand command : COMMANDS)
-		{
-			command.getLabels().forEach(label -> commands.put(label, command));
-		}
+    for (final PlaceholderCommand command : COMMANDS)
+    {
+      command.getLabels().forEach(label -> commands.put(label, command));
+    }
 
-		this.commands = commands.build();
-	}
+    this.commands = commands.build();
+  }
 
 
-	@Override
-	public boolean onCommand(@NotNull final CommandSender sender, @NotNull final Command command, @NotNull final String alias, @NotNull final String[] args)
-	{
-		if (args.length == 0)
-		{
-			final PlaceholderCommand fallback = commands.get("version");
-			if (fallback != null)
-			{
-				fallback.evaluate(plugin, sender, "", Collections.emptyList());
-			}
+  @Override
+  public boolean onCommand(@NotNull final CommandSender sender, @NotNull final Command command, @NotNull final String alias, @NotNull final String[] args)
+  {
+    if (args.length == 0)
+    {
+      final PlaceholderCommand fallback = commands.get("version");
+      if (fallback != null)
+      {
+        fallback.evaluate(plugin, sender, "", Collections.emptyList());
+      }
 
-			return true;
-		}
+      return true;
+    }
 
-		final String             search = args[0].toLowerCase();
-		final PlaceholderCommand target = commands.get(search);
+    final String             search = args[0].toLowerCase();
+    final PlaceholderCommand target = commands.get(search);
 
-		if (target == null)
-		{
-			Msg.msg(sender, "&cUnknown command &7" + search);
-			return true;
-		}
+    if (target == null)
+    {
+      Msg.msg(sender, "&cUnknown command &7" + search);
+      return true;
+    }
 
-		final String permission = target.getPermission();
-		if (permission != null && !permission.isEmpty() && !sender.hasPermission(permission))
-		{
-			Msg.msg(sender, "&cYou do not have permission to do this!");
-			return true;
-		}
+    final String permission = target.getPermission();
+    if (permission != null && !permission.isEmpty() && !sender.hasPermission(permission))
+    {
+      Msg.msg(sender, "&cYou do not have permission to do this!");
+      return true;
+    }
 
-		target.evaluate(plugin, sender, search, Arrays.asList(Arrays.copyOfRange(args, 1, args.length)));
+    target.evaluate(plugin, sender, search, Arrays.asList(Arrays.copyOfRange(args, 1, args.length)));
 
-		return true;
-	}
+    return true;
+  }
 
-	@Override
-	public List<String> onTabComplete(@NotNull final CommandSender sender, @NotNull final Command command, @NotNull final String alias, @NotNull final String[] args)
-	{
-		final List<String> suggestions = new ArrayList<>();
+  @Override
+  public List<String> onTabComplete(@NotNull final CommandSender sender, @NotNull final Command command, @NotNull final String alias, @NotNull final String[] args)
+  {
+    final List<String> suggestions = new ArrayList<>();
 
-		if (args.length > 1)
-		{
-			final PlaceholderCommand target = this.commands.get(args[0].toLowerCase());
+    if (args.length > 1)
+    {
+      final PlaceholderCommand target = this.commands.get(args[0].toLowerCase());
 
-			if (target != null)
-			{
-				target.complete(plugin, sender, args[0].toLowerCase(), Arrays.asList(Arrays.copyOfRange(args, 1, args.length)), suggestions);
-			}
+      if (target != null)
+      {
+        target.complete(plugin, sender, args[0].toLowerCase(), Arrays.asList(Arrays.copyOfRange(args, 1, args.length)), suggestions);
+      }
 
-			return suggestions;
-		}
+      return suggestions;
+    }
 
-		final Stream<String> targets = PlaceholderCommand.filterByPermission(sender, commands.values().stream()).map(PlaceholderCommand::getLabels).flatMap(Collection::stream);
-		PlaceholderCommand.suggestByParameter(targets, suggestions, args.length == 0 ? null : args[0]);
+    final Stream<String> targets = PlaceholderCommand.filterByPermission(sender, commands.values().stream()).map(PlaceholderCommand::getLabels).flatMap(Collection::stream);
+    PlaceholderCommand.suggestByParameter(targets, suggestions, args.length == 0 ? null : args[0]);
 
-		return suggestions;
-	}
+    return suggestions;
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloud.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloud.java
@@ -37,118 +37,118 @@ import java.util.stream.Stream;
 public final class CommandECloud extends PlaceholderCommand
 {
 
-	@Unmodifiable
-	private static final List<PlaceholderCommand> COMMANDS = ImmutableList.of(new CommandECloudClear(),
-																			  new CommandECloudToggle(),
-																			  new CommandECloudStatus(),
-																			  new CommandECloudUpdate(),
-																			  new CommandECloudRefresh(),
-																			  new CommandECloudDownload(),
-																			  new CommandECloudExpansionInfo(),
-																			  new CommandECloudExpansionList(),
-																			  new CommandECloudExpansionPlaceholders());
+  @Unmodifiable
+  private static final List<PlaceholderCommand> COMMANDS = ImmutableList.of(new CommandECloudClear(),
+                                        new CommandECloudToggle(),
+                                        new CommandECloudStatus(),
+                                        new CommandECloudUpdate(),
+                                        new CommandECloudRefresh(),
+                                        new CommandECloudDownload(),
+                                        new CommandECloudExpansionInfo(),
+                                        new CommandECloudExpansionList(),
+                                        new CommandECloudExpansionPlaceholders());
 
-	static
-	{
-		COMMANDS.forEach(command -> command.setPermission("placeholderapi.ecloud." + command.getLabel()));
-	}
+  static
+  {
+    COMMANDS.forEach(command -> command.setPermission("placeholderapi.ecloud." + command.getLabel()));
+  }
 
-	@NotNull
-	@Unmodifiable
-	private final Map<String, PlaceholderCommand> commands;
-
-
-	public CommandECloud()
-	{
-		super("ecloud");
-
-		final ImmutableMap.Builder<String, PlaceholderCommand> commands = ImmutableMap.builder();
-
-		for (final PlaceholderCommand command : COMMANDS)
-		{
-			command.getLabels().forEach(label -> commands.put(label, command));
-		}
-
-		this.commands = commands.build();
-	}
+  @NotNull
+  @Unmodifiable
+  private final Map<String, PlaceholderCommand> commands;
 
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.isEmpty())
-		{
-			Msg.msg(sender,
-					"&b&lPlaceholderAPI &8- &7eCloud Help Menu &8- ",
-					" ",
-					"&b/papi &fenable/disable/toggle",
-					"  &7&oEnable or disable the eCloud",
-					"&b/papi &fecloud status",
-					"  &7&oView status of the eCloud",
-					"&b/papi &fecloud list <all/{author}/installed> {page}",
-					"  &7&oList all/author specific available expansions",
-					"&b/papi &fecloud info <expansion name> {version}",
-					"  &7&oView information about a specific expansion available on the eCloud",
-					"&b/papi &fecloud placeholders <expansion name>",
-					"  &7&oView placeholders for an expansion",
-					"&b/papi &fecloud download <expansion name> {version}",
-					"  &7&oDownload an expansion from the eCloud",
-					"&b/papi &fecloud update <expansion name/all>",
-					"  &7&oUpdate a specific/all installed expansions",
-					"&b/papi &fecloud refresh",
-					"  &7&oFetch the most up to date list of expansions available.",
-					"&b/papi &fecloud clear",
-					"  &7&oClear the expansion cloud cache.");
+  public CommandECloud()
+  {
+    super("ecloud");
 
-			return;
-		}
+    final ImmutableMap.Builder<String, PlaceholderCommand> commands = ImmutableMap.builder();
 
-		final String             search = params.get(0).toLowerCase();
-		final PlaceholderCommand target = commands.get(search);
+    for (final PlaceholderCommand command : COMMANDS)
+    {
+      command.getLabels().forEach(label -> commands.put(label, command));
+    }
 
-		if (target == null)
-		{
-			Msg.msg(sender, "&cUnknown command &7ecloud " + search);
-			return;
-		}
+    this.commands = commands.build();
+  }
 
-		final String permission = target.getPermission();
-		if (permission != null && !permission.isEmpty() && !sender.hasPermission(permission))
-		{
-			Msg.msg(sender, "&cYou do not have permission to do this!");
-			return;
-		}
 
-		if (!(target instanceof CommandECloudToggle) && !plugin.getPlaceholderAPIConfig().isCloudEnabled())
-		{
-			Msg.msg(sender,
-					"&cThe eCloud Manager is not enabled!");
-			return;
-		}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.isEmpty())
+    {
+      Msg.msg(sender,
+          "&b&lPlaceholderAPI &8- &7eCloud Help Menu &8- ",
+          " ",
+          "&b/papi &fenable/disable/toggle",
+          "  &7&oEnable or disable the eCloud",
+          "&b/papi &fecloud status",
+          "  &7&oView status of the eCloud",
+          "&b/papi &fecloud list <all/{author}/installed> {page}",
+          "  &7&oList all/author specific available expansions",
+          "&b/papi &fecloud info <expansion name> {version}",
+          "  &7&oView information about a specific expansion available on the eCloud",
+          "&b/papi &fecloud placeholders <expansion name>",
+          "  &7&oView placeholders for an expansion",
+          "&b/papi &fecloud download <expansion name> {version}",
+          "  &7&oDownload an expansion from the eCloud",
+          "&b/papi &fecloud update <expansion name/all>",
+          "  &7&oUpdate a specific/all installed expansions",
+          "&b/papi &fecloud refresh",
+          "  &7&oFetch the most up to date list of expansions available.",
+          "&b/papi &fecloud clear",
+          "  &7&oClear the expansion cloud cache.");
 
-		target.evaluate(plugin, sender, search, params.subList(1, params.size()));
-	}
+      return;
+    }
 
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() <= 1)
-		{
-			final Stream<String> targets = filterByPermission(sender, commands.values().stream()).map(PlaceholderCommand::getLabels).flatMap(Collection::stream);
-			suggestByParameter(targets, suggestions, params.isEmpty() ? null : params.get(0));
+    final String             search = params.get(0).toLowerCase();
+    final PlaceholderCommand target = commands.get(search);
 
-			return; // send sub commands
-		}
+    if (target == null)
+    {
+      Msg.msg(sender, "&cUnknown command &7ecloud " + search);
+      return;
+    }
 
-		final String             search = params.get(0).toLowerCase();
-		final PlaceholderCommand target = commands.get(search);
+    final String permission = target.getPermission();
+    if (permission != null && !permission.isEmpty() && !sender.hasPermission(permission))
+    {
+      Msg.msg(sender, "&cYou do not have permission to do this!");
+      return;
+    }
 
-		if (target == null)
-		{
-			return;
-		}
+    if (!(target instanceof CommandECloudToggle) && !plugin.getPlaceholderAPIConfig().isCloudEnabled())
+    {
+      Msg.msg(sender,
+          "&cThe eCloud Manager is not enabled!");
+      return;
+    }
 
-		target.complete(plugin, sender, search, params.subList(1, params.size()), suggestions);
-	}
+    target.evaluate(plugin, sender, search, params.subList(1, params.size()));
+  }
+
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() <= 1)
+    {
+      final Stream<String> targets = filterByPermission(sender, commands.values().stream()).map(PlaceholderCommand::getLabels).flatMap(Collection::stream);
+      suggestByParameter(targets, suggestions, params.isEmpty() ? null : params.get(0));
+
+      return; // send sub commands
+    }
+
+    final String             search = params.get(0).toLowerCase();
+    final PlaceholderCommand target = commands.get(search);
+
+    if (target == null)
+    {
+      return;
+    }
+
+    target.complete(plugin, sender, search, params.subList(1, params.size()), suggestions);
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudClear.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudClear.java
@@ -32,17 +32,17 @@ import java.util.List;
 public final class CommandECloudClear extends PlaceholderCommand
 {
 
-	public CommandECloudClear()
-	{
-		super("clear");
-	}
+  public CommandECloudClear()
+  {
+    super("clear");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		plugin.getCloudExpansionManager().clean();
-		Msg.msg(sender,
-				"&aThe eCloud cache has been cleared!");
-	}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    plugin.getCloudExpansionManager().clean();
+    Msg.msg(sender,
+        "&aThe eCloud cache has been cleared!");
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudDownload.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudDownload.java
@@ -35,91 +35,91 @@ import java.util.stream.Stream;
 public final class CommandECloudDownload extends PlaceholderCommand
 {
 
-	public CommandECloudDownload()
-	{
-		super("download");
-	}
+  public CommandECloudDownload()
+  {
+    super("download");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cYou must supply the name of an expansion.");
-			return;
-		}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cYou must supply the name of an expansion.");
+      return;
+    }
 
-		final CloudExpansion expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0)).orElse(null);
-		if (expansion == null)
-		{
-			Msg.msg(sender,
-					"&cFailed to find an expansion named: &f" + params.get(0));
-			return;
-		}
+    final CloudExpansion expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0)).orElse(null);
+    if (expansion == null)
+    {
+      Msg.msg(sender,
+          "&cFailed to find an expansion named: &f" + params.get(0));
+      return;
+    }
 
-		final CloudExpansion.Version version;
-		if (params.size() < 2)
-		{
-			version = expansion.getVersion(expansion.getLatestVersion());
-			if (version == null)
-			{
-				Msg.msg(sender,
-						"&cCould not find latest version for expansion.");
-				return;
-			}
-		}
-		else
-		{
-			version = expansion.getVersion(params.get(1));
-			if (version == null)
-			{
-				Msg.msg(sender,
-						"&cCould not find specified version: &f" + params.get(1),
-						"&7Available versions: &f" + expansion.getAvailableVersions());
-				return;
-			}
-		}
+    final CloudExpansion.Version version;
+    if (params.size() < 2)
+    {
+      version = expansion.getVersion(expansion.getLatestVersion());
+      if (version == null)
+      {
+        Msg.msg(sender,
+            "&cCould not find latest version for expansion.");
+        return;
+      }
+    }
+    else
+    {
+      version = expansion.getVersion(params.get(1));
+      if (version == null)
+      {
+        Msg.msg(sender,
+            "&cCould not find specified version: &f" + params.get(1),
+            "&7Available versions: &f" + expansion.getAvailableVersions());
+        return;
+      }
+    }
 
-		plugin.getCloudExpansionManager().downloadExpansion(expansion, version).whenComplete((file, exception) -> {
-			if (exception != null)
-			{
-				Msg.msg(sender,
-						"&cFailed to download expansion: &f" + exception.getMessage());
-				return;
-			}
+    plugin.getCloudExpansionManager().downloadExpansion(expansion, version).whenComplete((file, exception) -> {
+      if (exception != null)
+      {
+        Msg.msg(sender,
+            "&cFailed to download expansion: &f" + exception.getMessage());
+        return;
+      }
 
-			Msg.msg(sender,
-					"&aSuccessfully downloaded expansion &f" + expansion.getName() + " [" + version.getVersion() + "] &ato file: &f" + file.getName(),
-					"&aMake sure to type &f/papi reload &ato enable your new expansion!");
+      Msg.msg(sender,
+          "&aSuccessfully downloaded expansion &f" + expansion.getName() + " [" + version.getVersion() + "] &ato file: &f" + file.getName(),
+          "&aMake sure to type &f/papi reload &ato enable your new expansion!");
 
-			plugin.getCloudExpansionManager().clean();
-			plugin.getCloudExpansionManager().fetch(plugin.getPlaceholderAPIConfig().cloudAllowUnverifiedExpansions());
-		});
-	}
+      plugin.getCloudExpansionManager().clean();
+      plugin.getCloudExpansionManager().fetch(plugin.getPlaceholderAPIConfig().cloudAllowUnverifiedExpansions());
+    });
+  }
 
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() > 2)
-		{
-			return;
-		}
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() > 2)
+    {
+      return;
+    }
 
-		if (params.size() <= 1)
-		{
-			final Stream<String> names = plugin.getCloudExpansionManager().getCloudExpansions().values().stream().map(CloudExpansion::getName).map(name -> name.replace(' ', '_'));
-			suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(0));
-			return;
-		}
+    if (params.size() <= 1)
+    {
+      final Stream<String> names = plugin.getCloudExpansionManager().getCloudExpansions().values().stream().map(CloudExpansion::getName).map(name -> name.replace(' ', '_'));
+      suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(0));
+      return;
+    }
 
-		final Optional<CloudExpansion> expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0));
-		if (!expansion.isPresent())
-		{
-			return;
-		}
+    final Optional<CloudExpansion> expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0));
+    if (!expansion.isPresent())
+    {
+      return;
+    }
 
-		suggestByParameter(expansion.get().getAvailableVersions().stream(), suggestions, params.get(1));
-	}
+    suggestByParameter(expansion.get().getAvailableVersions().stream(), suggestions, params.get(1));
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionInfo.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionInfo.java
@@ -35,102 +35,102 @@ import java.util.stream.Stream;
 public final class CommandECloudExpansionInfo extends PlaceholderCommand
 {
 
-	public CommandECloudExpansionInfo()
-	{
-		super("info");
-	}
+  public CommandECloudExpansionInfo()
+  {
+    super("info");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cYou must specify the name of the expansion.");
-			return;
-		}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cYou must specify the name of the expansion.");
+      return;
+    }
 
-		final CloudExpansion expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0)).orElse(null);
-		if (expansion == null)
-		{
-			Msg.msg(sender,
-					"&cThere is no expansion with the name: &f" + params.get(0));
-			return;
-		}
+    final CloudExpansion expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0)).orElse(null);
+    if (expansion == null)
+    {
+      Msg.msg(sender,
+          "&cThere is no expansion with the name: &f" + params.get(0));
+      return;
+    }
 
-		final StringBuilder builder = new StringBuilder();
+    final StringBuilder builder = new StringBuilder();
 
-		builder.append("&bExpansion: &f")
-			   .append(expansion.shouldUpdate() ? "&e" : "&a")
-			   .append(expansion.getName())
-			   .append('\n')
-			   .append("&bAuthor: &f")
-			   .append(expansion.getAuthor())
-			   .append('\n')
-			   .append("&bVerified: ")
-			   .append(expansion.isVerified() ? "&a&l✔" : "&c&l❌")
-			   .append('\n');
+    builder.append("&bExpansion: &f")
+         .append(expansion.shouldUpdate() ? "&e" : "&a")
+         .append(expansion.getName())
+         .append('\n')
+         .append("&bAuthor: &f")
+         .append(expansion.getAuthor())
+         .append('\n')
+         .append("&bVerified: ")
+         .append(expansion.isVerified() ? "&a&l✔" : "&c&l❌")
+         .append('\n');
 
-		if (params.size() < 2)
-		{
-			builder.append("&bLatest Version: &f")
-				   .append(expansion.getLatestVersion())
-				   .append('\n')
-				   .append("&bReleased: &f")
-				   .append(expansion.getTimeSinceLastUpdate())
-				   .append(" ago")
-				   .append('\n')
-				   .append("&bRelease Notes: &f")
-				   .append(expansion.getVersion().getReleaseNotes())
-				   .append('\n');
-		}
-		else
-		{
-			final CloudExpansion.Version version = expansion.getVersion(params.get(1));
-			if (version == null)
-			{
-				Msg.msg(sender,
-						"&cCould not find specified version: &f" + params.get(1),
-						"&aVersions: &f" + expansion.getAvailableVersions());
-				return;
-			}
+    if (params.size() < 2)
+    {
+      builder.append("&bLatest Version: &f")
+           .append(expansion.getLatestVersion())
+           .append('\n')
+           .append("&bReleased: &f")
+           .append(expansion.getTimeSinceLastUpdate())
+           .append(" ago")
+           .append('\n')
+           .append("&bRelease Notes: &f")
+           .append(expansion.getVersion().getReleaseNotes())
+           .append('\n');
+    }
+    else
+    {
+      final CloudExpansion.Version version = expansion.getVersion(params.get(1));
+      if (version == null)
+      {
+        Msg.msg(sender,
+            "&cCould not find specified version: &f" + params.get(1),
+            "&aVersions: &f" + expansion.getAvailableVersions());
+        return;
+      }
 
-			builder.append("&bVersion: &f")
-				   .append(version.getVersion())
-				   .append('\n')
-				   .append("&bRelease Notes: &f")
-				   .append(version.getReleaseNotes())
-				   .append('\n')
-				   .append("&bDownload URL: &f")
-				   .append(version.getUrl())
-				   .append('\n');
-		}
+      builder.append("&bVersion: &f")
+           .append(version.getVersion())
+           .append('\n')
+           .append("&bRelease Notes: &f")
+           .append(version.getReleaseNotes())
+           .append('\n')
+           .append("&bDownload URL: &f")
+           .append(version.getUrl())
+           .append('\n');
+    }
 
-		Msg.msg(sender, builder.toString());
-	}
+    Msg.msg(sender, builder.toString());
+  }
 
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() > 2)
-		{
-			return;
-		}
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() > 2)
+    {
+      return;
+    }
 
-		if (params.size() <= 1)
-		{
-			final Stream<String> names = plugin.getCloudExpansionManager().getCloudExpansions().values().stream().map(CloudExpansion::getName).map(name -> name.replace(' ', '_'));
-			suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(0));
-			return;
-		}
+    if (params.size() <= 1)
+    {
+      final Stream<String> names = plugin.getCloudExpansionManager().getCloudExpansions().values().stream().map(CloudExpansion::getName).map(name -> name.replace(' ', '_'));
+      suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(0));
+      return;
+    }
 
-		final Optional<CloudExpansion> expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0));
-		if (!expansion.isPresent())
-		{
-			return;
-		}
+    final Optional<CloudExpansion> expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0));
+    if (!expansion.isPresent())
+    {
+      return;
+    }
 
-		suggestByParameter(expansion.get().getAvailableVersions().stream(), suggestions, params.get(1));
-	}
+    suggestByParameter(expansion.get().getAvailableVersions().stream(), suggestions, params.get(1));
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionList.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionList.java
@@ -56,305 +56,305 @@ import java.util.stream.IntStream;
 public final class CommandECloudExpansionList extends PlaceholderCommand
 {
 
-	private static final int PAGE_SIZE = 10;
+  private static final int PAGE_SIZE = 10;
 
-	@NotNull
-	private static final Function<CloudExpansion, Object> EXPANSION_NAME            =
-			expansion -> (expansion.shouldUpdate() ? "&6" : expansion.hasExpansion() ? "&a" : "&7") + expansion.getName();
-	@NotNull
-	private static final Function<CloudExpansion, Object> EXPANSION_AUTHOR          =
-			expansion -> "&f" + expansion.getAuthor();
-	@NotNull
-	private static final Function<CloudExpansion, Object> EXPANSION_VERIFIED        =
-			expansion -> expansion.isVerified() ? "&aY" : "&cN";
-	@NotNull
-	private static final Function<CloudExpansion, Object> EXPANSION_LATEST_VERSION  =
-			expansion -> "&f" + expansion.getLatestVersion();
-	@NotNull
-	private static final Function<CloudExpansion, Object> EXPANSION_CURRENT_VERSION =
-			expansion -> "&f" + PlaceholderAPIPlugin.getInstance().getLocalExpansionManager().findExpansionByName(expansion.getName()).map(PlaceholderExpansion::getVersion).orElse("Unknown");
-
-
-	@Unmodifiable
-	private static final Set<String> OPTIONS = ImmutableSet.of("all", "installed");
+  @NotNull
+  private static final Function<CloudExpansion, Object> EXPANSION_NAME            =
+      expansion -> (expansion.shouldUpdate() ? "&6" : expansion.hasExpansion() ? "&a" : "&7") + expansion.getName();
+  @NotNull
+  private static final Function<CloudExpansion, Object> EXPANSION_AUTHOR          =
+      expansion -> "&f" + expansion.getAuthor();
+  @NotNull
+  private static final Function<CloudExpansion, Object> EXPANSION_VERIFIED        =
+      expansion -> expansion.isVerified() ? "&aY" : "&cN";
+  @NotNull
+  private static final Function<CloudExpansion, Object> EXPANSION_LATEST_VERSION  =
+      expansion -> "&f" + expansion.getLatestVersion();
+  @NotNull
+  private static final Function<CloudExpansion, Object> EXPANSION_CURRENT_VERSION =
+      expansion -> "&f" + PlaceholderAPIPlugin.getInstance().getLocalExpansionManager().findExpansionByName(expansion.getName()).map(PlaceholderExpansion::getVersion).orElse("Unknown");
 
 
-	public CommandECloudExpansionList()
-	{
-		super("list");
-	}
-
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cYou must specify an option. [all, {author}, installed]");
-			return;
-		}
+  @Unmodifiable
+  private static final Set<String> OPTIONS = ImmutableSet.of("all", "installed");
 
 
-		final boolean              installed  = params.get(0).equalsIgnoreCase("installed");
-		final List<CloudExpansion> expansions = Lists.newArrayList(getExpansions(params.get(0), plugin));
+  public CommandECloudExpansionList()
+  {
+    super("list");
+  }
 
-		if (expansions.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cNo expansions available to list.");
-			return;
-		}
-
-		expansions.sort(plugin.getPlaceholderAPIConfig().getExpansionSort().orElse(ExpansionSort.LATEST));
-
-		if (!(sender instanceof Player) && params.size() < 2)
-		{
-			final StringBuilder builder = new StringBuilder();
-
-			addExpansionTitle(builder, params.get(0), -1);
-			addExpansionTable(expansions,
-							  builder,
-							  1,
-							  installed ? "&9Version" : "&9Latest Version",
-							  installed ? EXPANSION_CURRENT_VERSION : EXPANSION_LATEST_VERSION);
-
-			Msg.msg(sender, builder.toString());
-			return;
-		}
-
-		final int page;
-
-		if (params.size() < 2)
-		{
-			page = 1;
-		}
-		else
-		{
-			//noinspection UnstableApiUsage
-			final Integer parsed = Ints.tryParse(params.get(1));
-			if (parsed == null)
-			{
-				Msg.msg(sender,
-						"&cPage number must be an integer.");
-				return;
-			}
-
-			final int limit = (int) Math.ceil((double) expansions.size() / PAGE_SIZE);
-
-			if (parsed < 1 || parsed > limit)
-			{
-				Msg.msg(sender,
-						"&cPage number must be in the range &8[&a1&7..&a" + limit + "&8]");
-				return;
-			}
-
-			page = parsed;
-		}
-
-		final StringBuilder        builder = new StringBuilder();
-		final List<CloudExpansion> values  = getPage(expansions, page - 1);
-
-		addExpansionTitle(builder, params.get(0), page);
-
-		if (!(sender instanceof Player))
-		{
-			addExpansionTable(values,
-							  builder,
-							  ((page - 1) * PAGE_SIZE) + 1,
-							  installed ? "&9Version" : "&9Latest Version",
-							  installed ? EXPANSION_CURRENT_VERSION : EXPANSION_LATEST_VERSION);
-
-			Msg.msg(sender, builder.toString());
-
-			return;
-		}
-
-		Msg.msg(sender, builder.toString());
-
-		final int limit = (int) Math.ceil((double) expansions.size() / PAGE_SIZE);
-
-		final JSONMessage message = getMessage(values, page, limit, params.get(0));
-		message.send(((Player) sender));
-	}
-
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() > 2)
-		{
-			return;
-		}
-
-		if (params.size() <= 1)
-		{
-			suggestByParameter(Sets.union(OPTIONS, plugin.getCloudExpansionManager().getCloudExpansionAuthors()).stream(), suggestions, params.isEmpty() ? null : params.get(0));
-			return;
-		}
-
-		suggestByParameter(IntStream.rangeClosed(1, (int) Math.ceil((double) getExpansions(params.get(0), plugin).size() / PAGE_SIZE)).mapToObj(Objects::toString), suggestions, params.get(1));
-	}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cYou must specify an option. [all, {author}, installed]");
+      return;
+    }
 
 
-	@NotNull
-	private static Collection<CloudExpansion> getExpansions(@NotNull final String target, @NotNull final PlaceholderAPIPlugin plugin)
-	{
-		switch (target.toLowerCase())
-		{
-			case "all":
-				return plugin.getCloudExpansionManager().getCloudExpansions().values();
-			case "installed":
-				return plugin.getCloudExpansionManager().getCloudExpansionsInstalled().values();
-			default:
-				return plugin.getCloudExpansionManager().getCloudExpansionsByAuthor(target).values();
-		}
-	}
+    final boolean              installed  = params.get(0).equalsIgnoreCase("installed");
+    final List<CloudExpansion> expansions = Lists.newArrayList(getExpansions(params.get(0), plugin));
 
-	@NotNull
-	private static List<CloudExpansion> getPage(@NotNull final List<CloudExpansion> expansions, final int page)
-	{
-		final int head = (page * PAGE_SIZE);
-		final int tail = Math.min(expansions.size(), head + PAGE_SIZE);
+    if (expansions.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cNo expansions available to list.");
+      return;
+    }
 
-		if (expansions.size() < head)
-		{
-			return Collections.emptyList();
-		}
+    expansions.sort(plugin.getPlaceholderAPIConfig().getExpansionSort().orElse(ExpansionSort.LATEST));
 
-		return expansions.subList(head, tail);
-	}
+    if (!(sender instanceof Player) && params.size() < 2)
+    {
+      final StringBuilder builder = new StringBuilder();
 
-	public static void addExpansionTitle(@NotNull final StringBuilder builder, @NotNull final String target, final int page)
-	{
-		switch (target.toLowerCase())
-		{
-			case "all":
-				builder.append("&bAll Expansions");
-				break;
-			case "installed":
-				builder.append("&bInstalled Expansions");
-				break;
-			default:
-				builder.append("&bExpansions by &f")
-					   .append(target);
-				break;
-		}
+      addExpansionTitle(builder, params.get(0), -1);
+      addExpansionTable(expansions,
+                builder,
+                1,
+                installed ? "&9Version" : "&9Latest Version",
+                installed ? EXPANSION_CURRENT_VERSION : EXPANSION_LATEST_VERSION);
 
-		if (page == -1)
-		{
-			builder.append('\n');
-			return;
-		}
+      Msg.msg(sender, builder.toString());
+      return;
+    }
 
-		builder.append(" &bPage&7: &a")
-			   .append(page)
-			   .append("&r")
-			   .append('\n');
-	}
+    final int page;
+
+    if (params.size() < 2)
+    {
+      page = 1;
+    }
+    else
+    {
+      //noinspection UnstableApiUsage
+      final Integer parsed = Ints.tryParse(params.get(1));
+      if (parsed == null)
+      {
+        Msg.msg(sender,
+            "&cPage number must be an integer.");
+        return;
+      }
+
+      final int limit = (int) Math.ceil((double) expansions.size() / PAGE_SIZE);
+
+      if (parsed < 1 || parsed > limit)
+      {
+        Msg.msg(sender,
+            "&cPage number must be in the range &8[&a1&7..&a" + limit + "&8]");
+        return;
+      }
+
+      page = parsed;
+    }
+
+    final StringBuilder        builder = new StringBuilder();
+    final List<CloudExpansion> values  = getPage(expansions, page - 1);
+
+    addExpansionTitle(builder, params.get(0), page);
+
+    if (!(sender instanceof Player))
+    {
+      addExpansionTable(values,
+                builder,
+                ((page - 1) * PAGE_SIZE) + 1,
+                installed ? "&9Version" : "&9Latest Version",
+                installed ? EXPANSION_CURRENT_VERSION : EXPANSION_LATEST_VERSION);
+
+      Msg.msg(sender, builder.toString());
+
+      return;
+    }
+
+    Msg.msg(sender, builder.toString());
+
+    final int limit = (int) Math.ceil((double) expansions.size() / PAGE_SIZE);
+
+    final JSONMessage message = getMessage(values, page, limit, params.get(0));
+    message.send(((Player) sender));
+  }
+
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() > 2)
+    {
+      return;
+    }
+
+    if (params.size() <= 1)
+    {
+      suggestByParameter(Sets.union(OPTIONS, plugin.getCloudExpansionManager().getCloudExpansionAuthors()).stream(), suggestions, params.isEmpty() ? null : params.get(0));
+      return;
+    }
+
+    suggestByParameter(IntStream.rangeClosed(1, (int) Math.ceil((double) getExpansions(params.get(0), plugin).size() / PAGE_SIZE)).mapToObj(Objects::toString), suggestions, params.get(1));
+  }
 
 
-	@NotNull
-	private static JSONMessage getMessage(@NotNull final List<CloudExpansion> expansions, final int page, final int limit, @NotNull final String target)
-	{
-		final SimpleDateFormat format = PlaceholderAPIPlugin.getDateFormat();
+  @NotNull
+  private static Collection<CloudExpansion> getExpansions(@NotNull final String target, @NotNull final PlaceholderAPIPlugin plugin)
+  {
+    switch (target.toLowerCase())
+    {
+      case "all":
+        return plugin.getCloudExpansionManager().getCloudExpansions().values();
+      case "installed":
+        return plugin.getCloudExpansionManager().getCloudExpansionsInstalled().values();
+      default:
+        return plugin.getCloudExpansionManager().getCloudExpansionsByAuthor(target).values();
+    }
+  }
 
-		final StringBuilder tooltip = new StringBuilder();
-		final JSONMessage   message = JSONMessage.create();
+  @NotNull
+  private static List<CloudExpansion> getPage(@NotNull final List<CloudExpansion> expansions, final int page)
+  {
+    final int head = (page * PAGE_SIZE);
+    final int tail = Math.min(expansions.size(), head + PAGE_SIZE);
 
-		for (int index = 0; index < expansions.size(); index++)
-		{
-			final CloudExpansion expansion = expansions.get(index);
+    if (expansions.size() < head)
+    {
+      return Collections.emptyList();
+    }
 
-			tooltip.append("&bClick to download this expansion!")
-				   .append('\n')
-				   .append('\n')
-				   .append("&bAuthor: &f")
-				   .append(expansion.getAuthor())
-				   .append('\n')
-				   .append("&bVerified: ")
-				   .append(expansion.isVerified() ? "&a&l✔&r" : "&c&l❌&r")
-				   .append('\n')
-				   .append("&bLatest Version: &f")
-				   .append(expansion.getLatestVersion())
-				   .append('\n')
-				   .append("&bReleased: &f")
-				   .append(format.format(expansion.getLastUpdate()));
+    return expansions.subList(head, tail);
+  }
 
-			final String description = expansion.getDescription();
-			if (description != null && !description.isEmpty())
-			{
-				tooltip.append('\n')
-					   .append('\n')
-					   .append("&f")
-					   .append(description.replace("\r", "").trim());
-			}
+  public static void addExpansionTitle(@NotNull final StringBuilder builder, @NotNull final String target, final int page)
+  {
+    switch (target.toLowerCase())
+    {
+      case "all":
+        builder.append("&bAll Expansions");
+        break;
+      case "installed":
+        builder.append("&bInstalled Expansions");
+        break;
+      default:
+        builder.append("&bExpansions by &f")
+             .append(target);
+        break;
+    }
 
-			message.then(Msg.color("&8" + (index + ((page - 1) * PAGE_SIZE) + 1) + ".&r " + (expansion.shouldUpdate() ? "&6" : expansion.hasExpansion() ? "&a" : "&7") + expansion.getName()));
+    if (page == -1)
+    {
+      builder.append('\n');
+      return;
+    }
 
-			message.tooltip(Msg.color(tooltip.toString()));
-			message.suggestCommand("/papi ecloud download " + expansion.getName());
+    builder.append(" &bPage&7: &a")
+         .append(page)
+         .append("&r")
+         .append('\n');
+  }
 
-			if (index < expansions.size() - 1)
-			{
-				message.newline();
-			}
 
-			tooltip.setLength(0);
-		}
+  @NotNull
+  private static JSONMessage getMessage(@NotNull final List<CloudExpansion> expansions, final int page, final int limit, @NotNull final String target)
+  {
+    final SimpleDateFormat format = PlaceholderAPIPlugin.getDateFormat();
 
-		if (limit > 1)
-		{
-			message.newline();
+    final StringBuilder tooltip = new StringBuilder();
+    final JSONMessage   message = JSONMessage.create();
 
-			message.then("◀")
-				   .color(page > 1 ? ChatColor.GRAY : ChatColor.DARK_GRAY);
-			if (page > 1)
-			{
-				message.runCommand("/papi ecloud list " + target + " " + (page - 1));
-			}
+    for (int index = 0; index < expansions.size(); index++)
+    {
+      final CloudExpansion expansion = expansions.get(index);
 
-			message.then(" " + page + " ").color(ChatColor.GREEN);
+      tooltip.append("&bClick to download this expansion!")
+           .append('\n')
+           .append('\n')
+           .append("&bAuthor: &f")
+           .append(expansion.getAuthor())
+           .append('\n')
+           .append("&bVerified: ")
+           .append(expansion.isVerified() ? "&a&l✔&r" : "&c&l❌&r")
+           .append('\n')
+           .append("&bLatest Version: &f")
+           .append(expansion.getLatestVersion())
+           .append('\n')
+           .append("&bReleased: &f")
+           .append(format.format(expansion.getLastUpdate()));
 
-			message.then("▶")
-				   .color(page < limit ? ChatColor.GRAY : ChatColor.DARK_GRAY);
-			if (page < limit)
-			{
-				message.runCommand("/papi ecloud list " + target + " " + (page + 1));
-			}
-		}
+      final String description = expansion.getDescription();
+      if (description != null && !description.isEmpty())
+      {
+        tooltip.append('\n')
+             .append('\n')
+             .append("&f")
+             .append(description.replace("\r", "").trim());
+      }
 
-		return message;
-	}
+      message.then(Msg.color("&8" + (index + ((page - 1) * PAGE_SIZE) + 1) + ".&r " + (expansion.shouldUpdate() ? "&6" : expansion.hasExpansion() ? "&a" : "&7") + expansion.getName()));
 
-	private static void addExpansionTable(@NotNull final List<CloudExpansion> expansions, @NotNull final StringBuilder message, final int startIndex, @NotNull final String versionTitle, @NotNull final Function<CloudExpansion, Object> versionFunction)
-	{
-		final Map<String, Function<CloudExpansion, Object>> functions = new LinkedHashMap<>();
+      message.tooltip(Msg.color(tooltip.toString()));
+      message.suggestCommand("/papi ecloud download " + expansion.getName());
 
-		final AtomicInteger counter = new AtomicInteger(startIndex);
-		functions.put("&f", expansion -> "&8" + counter.getAndIncrement() + ".");
+      if (index < expansions.size() - 1)
+      {
+        message.newline();
+      }
 
-		functions.put("&9Name", EXPANSION_NAME);
-		functions.put("&9Author", EXPANSION_AUTHOR);
-		functions.put("&9Verified", EXPANSION_VERIFIED);
-		functions.put(versionTitle, versionFunction);
+      tooltip.setLength(0);
+    }
 
-		final List<List<String>> rows = new ArrayList<>();
+    if (limit > 1)
+    {
+      message.newline();
 
-		rows.add(0, new ArrayList<>(functions.keySet()));
+      message.then("◀")
+           .color(page > 1 ? ChatColor.GRAY : ChatColor.DARK_GRAY);
+      if (page > 1)
+      {
+        message.runCommand("/papi ecloud list " + target + " " + (page - 1));
+      }
 
-		for (final CloudExpansion expansion : expansions)
-		{
-			rows.add(functions.values().stream().map(function -> function.apply(expansion)).map(Objects::toString).collect(Collectors.toList()));
-		}
+      message.then(" " + page + " ").color(ChatColor.GREEN);
 
-		final List<String> table = Format.tablify(Format.Align.LEFT, rows).orElse(Collections.emptyList());
-		if (table.isEmpty())
-		{
-			return;
-		}
+      message.then("▶")
+           .color(page < limit ? ChatColor.GRAY : ChatColor.DARK_GRAY);
+      if (page < limit)
+      {
+        message.runCommand("/papi ecloud list " + target + " " + (page + 1));
+      }
+    }
 
-		table.add(1, "&8" + Strings.repeat("-", table.get(0).length() - (rows.get(0).size() * 2)));
+    return message;
+  }
 
-		message.append(String.join("\n", table));
-	}
+  private static void addExpansionTable(@NotNull final List<CloudExpansion> expansions, @NotNull final StringBuilder message, final int startIndex, @NotNull final String versionTitle, @NotNull final Function<CloudExpansion, Object> versionFunction)
+  {
+    final Map<String, Function<CloudExpansion, Object>> functions = new LinkedHashMap<>();
+
+    final AtomicInteger counter = new AtomicInteger(startIndex);
+    functions.put("&f", expansion -> "&8" + counter.getAndIncrement() + ".");
+
+    functions.put("&9Name", EXPANSION_NAME);
+    functions.put("&9Author", EXPANSION_AUTHOR);
+    functions.put("&9Verified", EXPANSION_VERIFIED);
+    functions.put(versionTitle, versionFunction);
+
+    final List<List<String>> rows = new ArrayList<>();
+
+    rows.add(0, new ArrayList<>(functions.keySet()));
+
+    for (final CloudExpansion expansion : expansions)
+    {
+      rows.add(functions.values().stream().map(function -> function.apply(expansion)).map(Objects::toString).collect(Collectors.toList()));
+    }
+
+    final List<String> table = Format.tablify(Format.Align.LEFT, rows).orElse(Collections.emptyList());
+    if (table.isEmpty())
+    {
+      return;
+    }
+
+    table.add(1, "&8" + Strings.repeat("-", table.get(0).length() - (rows.get(0).size() * 2)));
+
+    message.append(String.join("\n", table));
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionPlaceholders.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionPlaceholders.java
@@ -36,61 +36,61 @@ import java.util.stream.Stream;
 public final class CommandECloudExpansionPlaceholders extends PlaceholderCommand
 {
 
-	public CommandECloudExpansionPlaceholders()
-	{
-		super("placeholders");
-	}
+  public CommandECloudExpansionPlaceholders()
+  {
+    super("placeholders");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cYou must specify the name of the expansion.");
-			return;
-		}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cYou must specify the name of the expansion.");
+      return;
+    }
 
-		final CloudExpansion expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0)).orElse(null);
-		if (expansion == null)
-		{
-			Msg.msg(sender,
-					"&cThere is no expansion with the name: &f" + params.get(0));
-			return;
-		}
+    final CloudExpansion expansion = plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0)).orElse(null);
+    if (expansion == null)
+    {
+      Msg.msg(sender,
+          "&cThere is no expansion with the name: &f" + params.get(0));
+      return;
+    }
 
-		final List<String> placeholders = expansion.getPlaceholders();
-		if (placeholders == null || placeholders.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cThe expansion specified does not have placeholders listed.");
-			return;
-		}
+    final List<String> placeholders = expansion.getPlaceholders();
+    if (placeholders == null || placeholders.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cThe expansion specified does not have placeholders listed.");
+      return;
+    }
 
-		final List<List<String>> partitions = Lists.partition(placeholders.stream().sorted().collect(Collectors.toList()), 10);
+    final List<List<String>> partitions = Lists.partition(placeholders.stream().sorted().collect(Collectors.toList()), 10);
 
-		Msg.msg(sender,
-				"&6" + placeholders.size() + "&7 placeholders: &a",
-				partitions.stream().map(partition -> "  " + String.join(", ", partition)).collect(Collectors.joining("\n")));
+    Msg.msg(sender,
+        "&6" + placeholders.size() + "&7 placeholders: &a",
+        partitions.stream().map(partition -> "  " + String.join(", ", partition)).collect(Collectors.joining("\n")));
 
-	}
+  }
 
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() > 1)
-		{
-			return;
-		}
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() > 1)
+    {
+      return;
+    }
 
-		final Stream<String> names = plugin.getCloudExpansionManager()
-										   .getCloudExpansions()
-										   .values()
-										   .stream()
-										   .map(CloudExpansion::getName)
-										   .map(name -> name.replace(' ', '_'));
+    final Stream<String> names = plugin.getCloudExpansionManager()
+                       .getCloudExpansions()
+                       .values()
+                       .stream()
+                       .map(CloudExpansion::getName)
+                       .map(name -> name.replace(' ', '_'));
 
-		suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(0));
-	}
+    suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(0));
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudRefresh.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudRefresh.java
@@ -32,19 +32,19 @@ import java.util.List;
 public final class CommandECloudRefresh extends PlaceholderCommand
 {
 
-	public CommandECloudRefresh()
-	{
-		super("refresh");
-	}
+  public CommandECloudRefresh()
+  {
+    super("refresh");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		plugin.getCloudExpansionManager().clean();
-		plugin.getCloudExpansionManager().fetch(plugin.getPlaceholderAPIConfig().cloudAllowUnverifiedExpansions());
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    plugin.getCloudExpansionManager().clean();
+    plugin.getCloudExpansionManager().fetch(plugin.getPlaceholderAPIConfig().cloudAllowUnverifiedExpansions());
 
-		Msg.msg(sender,
-				"&aThe eCloud Manager has been refreshed!");
-	}
+    Msg.msg(sender,
+        "&aThe eCloud Manager has been refreshed!");
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudStatus.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudStatus.java
@@ -33,31 +33,31 @@ import java.util.List;
 public final class CommandECloudStatus extends PlaceholderCommand
 {
 
-	public CommandECloudStatus()
-	{
-		super("status");
-	}
+  public CommandECloudStatus()
+  {
+    super("status");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		final CloudExpansionManager manager = plugin.getCloudExpansionManager();
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    final CloudExpansionManager manager = plugin.getCloudExpansionManager();
 
-		final int updateCount    = manager.getCloudUpdateCount();
-		final int authorCount    = manager.getCloudExpansionAuthorCount();
-		final int expansionCount = manager.getCloudExpansions().size();
+    final int updateCount    = manager.getCloudUpdateCount();
+    final int authorCount    = manager.getCloudExpansionAuthorCount();
+    final int expansionCount = manager.getCloudExpansions().size();
 
-		final StringBuilder builder = new StringBuilder();
+    final StringBuilder builder = new StringBuilder();
 
-		builder.append("&bThere are &a").append(expansionCount).append("&b expansions available on the eCloud.").append('\n');
-		builder.append("&7A total of &f").append(authorCount).append("&7 authors have contributed to the eCloud.").append('\n');
+    builder.append("&bThere are &a").append(expansionCount).append("&b expansions available on the eCloud.").append('\n');
+    builder.append("&7A total of &f").append(authorCount).append("&7 authors have contributed to the eCloud.").append('\n');
 
-		if (updateCount > 0)
-		{
-			builder.append("&eYou have &a").append(updateCount).append("&e expansions installed that have updates available.");
-		}
+    if (updateCount > 0)
+    {
+      builder.append("&eYou have &a").append(updateCount).append("&e expansions installed that have updates available.");
+    }
 
-		Msg.msg(sender,builder.toString());
-	}
+    Msg.msg(sender,builder.toString());
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudToggle.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudToggle.java
@@ -32,48 +32,48 @@ import java.util.List;
 public final class CommandECloudToggle extends PlaceholderCommand
 {
 
-	public CommandECloudToggle()
-	{
-		super("toggle", "enable", "disable");
-	}
+  public CommandECloudToggle()
+  {
+    super("toggle", "enable", "disable");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		final boolean desiredState;
-		final boolean currentState = plugin.getPlaceholderAPIConfig().isCloudEnabled();
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    final boolean desiredState;
+    final boolean currentState = plugin.getPlaceholderAPIConfig().isCloudEnabled();
 
-		switch (alias.toLowerCase())
-		{
-			case "enable":
-				desiredState = true;
-				break;
-			case "disable":
-				desiredState = false;
-				break;
-			default:
-				desiredState = !currentState;
-				break;
-		}
+    switch (alias.toLowerCase())
+    {
+      case "enable":
+        desiredState = true;
+        break;
+      case "disable":
+        desiredState = false;
+        break;
+      default:
+        desiredState = !currentState;
+        break;
+    }
 
-		if (desiredState == currentState)
-		{
-			Msg.msg(sender, "&7The eCloud Manager is already " + (desiredState ? "enabled" : "disabled"));
-			return;
-		}
+    if (desiredState == currentState)
+    {
+      Msg.msg(sender, "&7The eCloud Manager is already " + (desiredState ? "enabled" : "disabled"));
+      return;
+    }
 
-		plugin.getPlaceholderAPIConfig().setCloudEnabled(desiredState);
+    plugin.getPlaceholderAPIConfig().setCloudEnabled(desiredState);
 
-		if (desiredState)
-		{
-			plugin.getCloudExpansionManager().load();
-		}
-		else
-		{
-			plugin.getCloudExpansionManager().kill();
-		}
+    if (desiredState)
+    {
+      plugin.getCloudExpansionManager().load();
+    }
+    else
+    {
+      plugin.getCloudExpansionManager().kill();
+    }
 
-		Msg.msg(sender, "&aThe eCloud Manager has been " + (desiredState ? "enabled" : "disabled"));
-	}
+    Msg.msg(sender, "&aThe eCloud Manager has been " + (desiredState ? "enabled" : "disabled"));
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudUpdate.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudUpdate.java
@@ -45,101 +45,101 @@ import java.util.stream.Collectors;
 public final class CommandECloudUpdate extends PlaceholderCommand
 {
 
-	public CommandECloudUpdate()
-	{
-		super("update");
-	}
+  public CommandECloudUpdate()
+  {
+    super("update");
+  }
 
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cYou must define 'all' or the name of an expansion to update.");
-			return;
-		}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cYou must define 'all' or the name of an expansion to update.");
+      return;
+    }
 
-		final boolean              multiple   = params.get(0).equalsIgnoreCase("all");
-		final List<CloudExpansion> expansions = new ArrayList<>();
+    final boolean              multiple   = params.get(0).equalsIgnoreCase("all");
+    final List<CloudExpansion> expansions = new ArrayList<>();
 
-		// gather target expansions
-		if (multiple)
-		{
-			expansions.addAll(plugin.getCloudExpansionManager().getCloudExpansionsInstalled().values());
-		}
-		else
-		{
-			plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0)).ifPresent(expansions::add);
-		}
+    // gather target expansions
+    if (multiple)
+    {
+      expansions.addAll(plugin.getCloudExpansionManager().getCloudExpansionsInstalled().values());
+    }
+    else
+    {
+      plugin.getCloudExpansionManager().findCloudExpansionByName(params.get(0)).ifPresent(expansions::add);
+    }
 
-		// remove the ones that are the latest version
-		expansions.removeIf(expansion -> !expansion.shouldUpdate());
+    // remove the ones that are the latest version
+    expansions.removeIf(expansion -> !expansion.shouldUpdate());
 
-		if (expansions.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cNo updates available for " + (!multiple ? "this expansion." : "your active expansions."));
-			return;
-		}
+    if (expansions.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cNo updates available for " + (!multiple ? "this expansion." : "your active expansions."));
+      return;
+    }
 
-		Msg.msg(sender,
-				"&aUpdating expansions: " + expansions.stream().map(CloudExpansion::getName).collect(Collectors.joining("&7, &6", "&8[&6", "&8]&r")));
-
-
-		Futures.onMainThread(plugin, downloadAndDiscover(expansions, plugin), (classes, exception) -> {
-			if (exception != null)
-			{
-				Msg.msg(sender,
-						"&cFailed to update expansions: &e" + exception.getMessage());
-				return;
-			}
-
-			Msg.msg(sender,
-					"&aSuccessfully downloaded updates, registering new versions.");
+    Msg.msg(sender,
+        "&aUpdating expansions: " + expansions.stream().map(CloudExpansion::getName).collect(Collectors.joining("&7, &6", "&8[&6", "&8]&r")));
 
 
-			final String message = classes.stream()
-										  .filter(Objects::nonNull)
-										  .map(plugin.getLocalExpansionManager()::register)
-										  .filter(Optional::isPresent)
-										  .map(Optional::get)
-										  .map(expansion -> "  &a" + expansion.getName() + " &f" + expansion.getVersion())
-										  .collect(Collectors.joining("\n"));
+    Futures.onMainThread(plugin, downloadAndDiscover(expansions, plugin), (classes, exception) -> {
+      if (exception != null)
+      {
+        Msg.msg(sender,
+            "&cFailed to update expansions: &e" + exception.getMessage());
+        return;
+      }
 
-			Msg.msg(sender,
-					"&7Registered expansions:", message);
-
-		});
-	}
-
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() > 1)
-		{
-			return;
-		}
-
-		final List<CloudExpansion> installed = Lists.newArrayList(plugin.getCloudExpansionManager().getCloudExpansionsInstalled().values());
-		installed.removeIf(expansion -> !expansion.shouldUpdate());
-
-		if (!installed.isEmpty() && (params.isEmpty() || "all".startsWith(params.get(0).toLowerCase())))
-		{
-			suggestions.add("all");
-		}
-
-		suggestByParameter(installed.stream().map(CloudExpansion::getName).map(name -> name.replace(" ", "_")), suggestions, params.isEmpty() ? null : params.get(0));
-	}
+      Msg.msg(sender,
+          "&aSuccessfully downloaded updates, registering new versions.");
 
 
-	private static CompletableFuture<List<@Nullable Class<? extends PlaceholderExpansion>>> downloadAndDiscover(@NotNull final List<CloudExpansion> expansions, @NotNull final PlaceholderAPIPlugin plugin)
-	{
-		return expansions.stream()
-						 .map(expansion -> plugin.getCloudExpansionManager().downloadExpansion(expansion, expansion.getVersion()))
-						 .map(future -> future.thenCompose(plugin.getLocalExpansionManager()::findExpansionInFile))
-						 .collect(Futures.collector());
-	}
+      final String message = classes.stream()
+                      .filter(Objects::nonNull)
+                      .map(plugin.getLocalExpansionManager()::register)
+                      .filter(Optional::isPresent)
+                      .map(Optional::get)
+                      .map(expansion -> "  &a" + expansion.getName() + " &f" + expansion.getVersion())
+                      .collect(Collectors.joining("\n"));
+
+      Msg.msg(sender,
+          "&7Registered expansions:", message);
+
+    });
+  }
+
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() > 1)
+    {
+      return;
+    }
+
+    final List<CloudExpansion> installed = Lists.newArrayList(plugin.getCloudExpansionManager().getCloudExpansionsInstalled().values());
+    installed.removeIf(expansion -> !expansion.shouldUpdate());
+
+    if (!installed.isEmpty() && (params.isEmpty() || "all".startsWith(params.get(0).toLowerCase())))
+    {
+      suggestions.add("all");
+    }
+
+    suggestByParameter(installed.stream().map(CloudExpansion::getName).map(name -> name.replace(" ", "_")), suggestions, params.isEmpty() ? null : params.get(0));
+  }
+
+
+  private static CompletableFuture<List<@Nullable Class<? extends PlaceholderExpansion>>> downloadAndDiscover(@NotNull final List<CloudExpansion> expansions, @NotNull final PlaceholderAPIPlugin plugin)
+  {
+    return expansions.stream()
+             .map(expansion -> plugin.getCloudExpansionManager().downloadExpansion(expansion, expansion.getVersion()))
+             .map(future -> future.thenCompose(plugin.getLocalExpansionManager()::findExpansionInFile))
+             .collect(Futures.collector());
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandDump.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandDump.java
@@ -42,9 +42,10 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.logging.Level;
@@ -53,147 +54,158 @@ import java.util.stream.Collectors;
 public final class CommandDump extends PlaceholderCommand
 {
 
-	@NotNull
-	private static final String URL = "https://paste.helpch.at/";
+  @NotNull
+  private static final String URL = "https://paste.helpch.at/";
 
-	@NotNull
-	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG)
-																		  .withLocale(Locale.US)
-																		  .withZone(ZoneId.of("UTC"));
-
-
-	public CommandDump()
-	{
-		super("dump");
-	}
-
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		postDump(makeDump(plugin)).whenComplete((key, exception) -> {
-			if (exception != null)
-			{
-				plugin.getLogger().log(Level.WARNING, "failed to post dump details", exception);
-
-				Msg.msg(sender,
-						"&cFailed to post dump details, check console.");
-				return;
-			}
-
-			Msg.msg(sender,
-					"&aSuccessfully posted dump: " + URL + key);
-		});
-	}
-
-	@NotNull
-	private CompletableFuture<String> postDump(@NotNull final String dump)
-	{
-		return CompletableFuture.supplyAsync(() -> {
-			try
-			{
-				final HttpURLConnection connection = ((HttpURLConnection) new URL(URL + "documents").openConnection());
-				connection.setRequestMethod("POST");
-				connection.setRequestProperty("Content-Type", "text/plain; charset=utf-8");
-				connection.setDoOutput(true);
-
-				connection.connect();
-
-				try (final OutputStream stream = connection.getOutputStream())
-				{
-					stream.write(dump.getBytes(StandardCharsets.UTF_8));
-				}
-
-				try (final InputStream stream = connection.getInputStream())
-				{
-					//noinspection UnstableApiUsage
-					final String json = CharStreams.toString(new InputStreamReader(stream, StandardCharsets.UTF_8));
-					return JsonParser.parseString(json).getAsJsonObject().get("key").getAsString();
-				}
-			}
-			catch (final IOException ex)
-			{
-				throw new CompletionException(ex);
-			}
-		});
-	}
-
-	@NotNull
-	private String makeDump(@NotNull final PlaceholderAPIPlugin plugin)
-	{
-		final StringBuilder builder = new StringBuilder();
-
-		builder.append("Generated: ")
-			   .append(DATE_FORMAT.format(Instant.now()))
-			   .append("\n\n");
-
-		builder.append("PlaceholderAPI: ")
-			   .append(plugin.getDescription().getVersion())
-			   .append("\n\n");
-
-		builder.append("Expansions Registered:")
-			   .append('\n');
+  @NotNull
+  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG)
+                                                                        .withLocale(Locale.US)
+                                                                        .withZone(ZoneId.of("UTC"));
 
 
-		final Map<String, List<PlaceholderExpansion>> expansions = plugin.getLocalExpansionManager()
-																		 .getExpansions()
-																		 .stream()
-																		 .collect(Collectors.groupingBy(PlaceholderExpansion::getAuthor));
+  public CommandDump()
+  {
+    super("dump");
+  }
 
-		for (final Map.Entry<String, List<PlaceholderExpansion>> expansionsByAuthor : expansions.entrySet())
-		{
-			builder.append("  ")
-				   .append(expansionsByAuthor.getKey())
-				   .append(": ")
-				   .append('\n');
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    postDump(makeDump(plugin)).whenComplete((key, exception) -> {
+      if (exception != null)
+      {
+        plugin.getLogger().log(Level.WARNING, "failed to post dump details", exception);
 
-			for (final PlaceholderExpansion expansion : expansionsByAuthor.getValue())
-			{
-				builder.append("    ")
-					   .append(expansion.getName())
-					   .append(':')
-					   .append(expansion.getVersion())
-					   .append('\n');
+        Msg.msg(sender,
+            "&cFailed to post dump details, check console.");
+        return;
+      }
+
+      Msg.msg(sender,
+          "&aSuccessfully posted dump: " + URL + key);
+    });
+  }
+
+  @NotNull
+  private CompletableFuture<String> postDump(@NotNull final String dump)
+  {
+    return CompletableFuture.supplyAsync(() -> {
+      try
+      {
+        final HttpURLConnection connection = ((HttpURLConnection) new URL(URL + "documents").openConnection());
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Content-Type", "text/plain; charset=utf-8");
+        connection.setDoOutput(true);
+
+        connection.connect();
+
+        try (final OutputStream stream = connection.getOutputStream())
+        {
+          stream.write(dump.getBytes(StandardCharsets.UTF_8));
+        }
+
+        try (final InputStream stream = connection.getInputStream())
+        {
+          //noinspection UnstableApiUsage
+          final String json = CharStreams.toString(new InputStreamReader(stream, StandardCharsets.UTF_8));
+          return JsonParser.parseString(json).getAsJsonObject().get("key").getAsString();
+        }
+      }
+      catch (final IOException ex)
+      {
+        throw new CompletionException(ex);
+      }
+    });
+  }
+
+  @NotNull
+  private String makeDump(@NotNull final PlaceholderAPIPlugin plugin)
+  {
+    final StringBuilder builder = new StringBuilder();
+
+    builder.append("Generated: ")
+         .append(DATE_FORMAT.format(Instant.now()))
+         .append("\n\n");
+
+    builder.append("PlaceholderAPI: ")
+         .append(plugin.getDescription().getVersion())
+         .append("\n\n");
+
+    builder.append("Expansions Registered:")
+         .append('\n');
+    
+    final List<PlaceholderExpansion> expansions = plugin.getLocalExpansionManager()
+                                .getExpansions()
+                                .stream()
+                                .sorted(Comparator.comparing(PlaceholderExpansion::getAuthor))
+                                .collect(Collectors.toList());
+    
+    int size = 0;
+	
+		for(final PlaceholderExpansion placeholderExpansion : expansions){
+			if (placeholderExpansion.getIdentifier().length() > size) {
+				size = placeholderExpansion.getIdentifier().length();
 			}
 		}
+    
+    for (final PlaceholderExpansion expansion : expansions) {
+      builder.append("  ")
+           .append(String.format("%-" + size + "s", expansion.getIdentifier()))
+           .append(" [Author: ")
+           .append(expansion.getAuthor())
+           .append(", Version: ")
+           .append(expansion.getVersion())
+           .append("]\n");
+      
+    }
 
-		builder.append('\n');
+    builder.append('\n');
 
-		builder.append("Expansions Directory:")
-			   .append('\n');
+    builder.append("Expansions Directory:")
+         .append('\n');
 
-		final String[] jars = plugin.getLocalExpansionManager()
-									.getExpansionsFolder()
-									.list((dir, name) -> name.toLowerCase().endsWith(".jar"));
+    final String[] jars = plugin.getLocalExpansionManager()
+                  .getExpansionsFolder()
+                  .list((dir, name) -> name.toLowerCase().endsWith(".jar"));
 
-		for (final String jar : jars)
-		{
-			builder.append("  ")
-				   .append(jar)
-				   .append('\n');
-		}
+    for (final String jar : jars)
+    {
+      builder.append("  ")
+           .append(jar)
+           .append('\n');
+    }
 
-		builder.append('\n');
+    builder.append('\n');
 
 
-		builder.append("Server Info: ")
-			   .append(plugin.getServer().getBukkitVersion())
-			   .append('/')
-			   .append(plugin.getServer().getVersion())
-			   .append("\n\n");
+    builder.append("Server Info: ")
+         .append(plugin.getServer().getBukkitVersion())
+         .append('/')
+         .append(plugin.getServer().getVersion())
+         .append("\n\n");
 
-		builder.append("Plugin Info:")
-			   .append('\n');
+    builder.append("Plugin Info:")
+         .append('\n');
+    
+    Plugin[] plugins = plugin.getServer().getPluginManager().getPlugins();
+    
+    for (final String pluginName : Arrays.stream(plugins).map(Plugin::getName).collect(Collectors.toList())) {
+      if (pluginName.length() > size) {
+        size = pluginName.length();
+      }
+    }
 
-		for (final Plugin other : plugin.getServer().getPluginManager().getPlugins())
-		{
-			builder.append("  ")
-				   .append(other.getName())
-				   .append(": ")
-				   .append(other.getDescription().getVersion())
-				   .append('\n');
-		}
+    for (final Plugin other : plugins)
+    {
+      builder.append("  ")
+           .append(String.format("%-" + size + "s", other.getName()))
+           .append(" [Version: ")
+           .append(other.getDescription().getVersion())
+           .append("]")
+           .append("\n");
+    }
 
-		return builder.toString();
-	}
+    return builder.toString();
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandDump.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandDump.java
@@ -137,14 +137,15 @@ public final class CommandDump extends PlaceholderCommand
     final List<PlaceholderExpansion> expansions = plugin.getLocalExpansionManager()
                                 .getExpansions()
                                 .stream()
+                                .sorted(Comparator.comparing(PlaceholderExpansion::getIdentifier))
                                 .sorted(Comparator.comparing(PlaceholderExpansion::getAuthor))
                                 .collect(Collectors.toList());
     
     int size = 0;
 	
-		for(final PlaceholderExpansion placeholderExpansion : expansions){
-			if (placeholderExpansion.getIdentifier().length() > size) {
-				size = placeholderExpansion.getIdentifier().length();
+		for(final String name : expansions.stream().map(PlaceholderExpansion::getIdentifier).collect(Collectors.toList())){
+			if (name.length() > size) {
+				size = name.length();
 			}
 		}
     
@@ -187,9 +188,11 @@ public final class CommandDump extends PlaceholderCommand
     builder.append("Plugin Info:")
          .append('\n');
     
-    Plugin[] plugins = plugin.getServer().getPluginManager().getPlugins();
+    List<Plugin> plugins = Arrays.stream(plugin.getServer().getPluginManager().getPlugins())
+                                 .sorted(Comparator.comparing(Plugin::getName))
+                                 .collect(Collectors.toList());
     
-    for (final String pluginName : Arrays.stream(plugins).map(Plugin::getName).collect(Collectors.toList())) {
+    for (final String pluginName : plugins.stream().map(Plugin::getName).collect(Collectors.toList())) {
       if (pluginName.length() > size) {
         size = pluginName.length();
       }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandExpansionRegister.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandExpansionRegister.java
@@ -39,79 +39,79 @@ import java.util.logging.Level;
 public final class CommandExpansionRegister extends PlaceholderCommand
 {
 
-	public CommandExpansionRegister()
-	{
-		super("register");
-	}
+  public CommandExpansionRegister()
+  {
+    super("register");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.size() < 1)
-		{
-			Msg.msg(sender,
-					"&cYou must specify the name of an expansion file.");
-			return;
-		}
-
-
-		final LocalExpansionManager manager = plugin.getLocalExpansionManager();
-
-		final File file = new File(manager.getExpansionsFolder(), params.get(0));
-		if (!file.exists())
-		{
-			Msg.msg(sender,
-					"&cThe file &f" + file.getName() + "&c doesn't exist!");
-			return;
-		}
-
-		Futures.onMainThread(plugin, manager.findExpansionInFile(file), (clazz, exception) -> {
-			if (exception != null)
-			{
-				Msg.msg(sender,
-						"&cFailed to find expansion in file: &f" + file);
-
-				plugin.getLogger().log(Level.WARNING, "failed to find expansion in file: " + file, exception);
-				return;
-			}
-
-			if (clazz == null)
-			{
-				Msg.msg(sender,
-						"&cNo expansion class found in file: &f" + file);
-				return;
-			}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.size() < 1)
+    {
+      Msg.msg(sender,
+          "&cYou must specify the name of an expansion file.");
+      return;
+    }
 
 
-			final Optional<PlaceholderExpansion> expansion = manager.register(clazz);
-			if (!expansion.isPresent())
-			{
-				Msg.msg(sender,
-						"&cFailed to register expansion from &f" + params.get(0));
-				return;
-			}
+    final LocalExpansionManager manager = plugin.getLocalExpansionManager();
 
-			Msg.msg(sender,
-					"&aSuccessfully registered expansion: &f" + expansion.get().getName());
+    final File file = new File(manager.getExpansionsFolder(), params.get(0));
+    if (!file.exists())
+    {
+      Msg.msg(sender,
+          "&cThe file &f" + file.getName() + "&c doesn't exist!");
+      return;
+    }
 
-		});
-	}
+    Futures.onMainThread(plugin, manager.findExpansionInFile(file), (clazz, exception) -> {
+      if (exception != null)
+      {
+        Msg.msg(sender,
+            "&cFailed to find expansion in file: &f" + file);
 
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() > 1)
-		{
-			return;
-		}
+        plugin.getLogger().log(Level.WARNING, "failed to find expansion in file: " + file, exception);
+        return;
+      }
 
-		final String[] fileNames = plugin.getLocalExpansionManager().getExpansionsFolder().list((dir, name) -> name.endsWith(".jar"));
-		if (fileNames == null || fileNames.length == 0)
-		{
-			return;
-		}
+      if (clazz == null)
+      {
+        Msg.msg(sender,
+            "&cNo expansion class found in file: &f" + file);
+        return;
+      }
 
-		suggestByParameter(Arrays.stream(fileNames), suggestions, params.isEmpty() ? null : params.get(0));
-	}
+
+      final Optional<PlaceholderExpansion> expansion = manager.register(clazz);
+      if (!expansion.isPresent())
+      {
+        Msg.msg(sender,
+            "&cFailed to register expansion from &f" + params.get(0));
+        return;
+      }
+
+      Msg.msg(sender,
+          "&aSuccessfully registered expansion: &f" + expansion.get().getName());
+
+    });
+  }
+
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() > 1)
+    {
+      return;
+    }
+
+    final String[] fileNames = plugin.getLocalExpansionManager().getExpansionsFolder().list((dir, name) -> name.endsWith(".jar"));
+    if (fileNames == null || fileNames.length == 0)
+    {
+      return;
+    }
+
+    suggestByParameter(Arrays.stream(fileNames), suggestions, params.isEmpty() ? null : params.get(0));
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandExpansionUnregister.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandExpansionUnregister.java
@@ -35,46 +35,46 @@ import java.util.Optional;
 public final class CommandExpansionUnregister extends PlaceholderCommand
 {
 
-	public CommandExpansionUnregister()
-	{
-		super("unregister");
-	}
+  public CommandExpansionUnregister()
+  {
+    super("unregister");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cYou must specify the name of the expansion.");
-			return;
-		}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cYou must specify the name of the expansion.");
+      return;
+    }
 
-		final Optional<PlaceholderExpansion> expansion = plugin.getLocalExpansionManager().findExpansionByName(params.get(0));
-		if (!expansion.isPresent())
-		{
-			Msg.msg(sender,
-					"&cThere is no expansion loaded with the identifier: &f" + params.get(0));
-			return;
-		}
+    final Optional<PlaceholderExpansion> expansion = plugin.getLocalExpansionManager().findExpansionByName(params.get(0));
+    if (!expansion.isPresent())
+    {
+      Msg.msg(sender,
+          "&cThere is no expansion loaded with the identifier: &f" + params.get(0));
+      return;
+    }
 
 
-		final String message = !expansion.get().unregister() ?
-							   "&cFailed to unregister expansion: &f" :
-							   "&aSuccessfully unregistered expansion: &f";
+    final String message = !expansion.get().unregister() ?
+                 "&cFailed to unregister expansion: &f" :
+                 "&aSuccessfully unregistered expansion: &f";
 
-		Msg.msg(sender, message + expansion.get().getName());
-	}
+    Msg.msg(sender, message + expansion.get().getName());
+  }
 
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() > 1)
-		{
-			return;
-		}
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() > 1)
+    {
+      return;
+    }
 
-		suggestByParameter(PlaceholderAPI.getRegisteredIdentifiers().stream(), suggestions, params.isEmpty() ? null : params.get(0));
-	}
+    suggestByParameter(PlaceholderAPI.getRegisteredIdentifiers().stream(), suggestions, params.isEmpty() ? null : params.get(0));
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandHelp.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandHelp.java
@@ -33,42 +33,42 @@ import java.util.List;
 public final class CommandHelp extends PlaceholderCommand
 {
 
-	public CommandHelp()
-	{
-		super("help");
-	}
+  public CommandHelp()
+  {
+    super("help");
+  }
 
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		final PluginDescriptionFile description = plugin.getDescription();
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    final PluginDescriptionFile description = plugin.getDescription();
 
-		Msg.msg(sender,
-				"&b&lPlaceholderAPI &8- &7Help Menu &8- &7(&f" + description.getVersion() + "&7)",
-				" ",
-				"&b/papi &fversion",
-				"  &7&oView plugin info/version",
-				"&b/papi &freload",
-				"  &7&oReload the config of PAPI",
-				"&b/papi &flist",
-				"  &7&oList active expansions",
-				"&b/papi &finfo &9<placeholder name>",
-				"  &7&oView information for a specific expansion",
-				"&b/papi &fparse &9<me/player name> <message>",
-				"  &7&oParse a message with placeholders",
-				"&b/papi &fbcparse &9<me/player name> <message>",
-				"  &7&oParse a message with placeholders and broadcast it",
-				"&b/papi &fparserel &9<player one> <player two> <message>",
-				"  &7&oParse a message with relational placeholders",
-				"&b/papi &fcmdparse &9<me/player> <command with placeholders>",
-				"  &7&oParse a message with relational placeholders",
-				"&b/papi &fregister &9<file name>",
-				"  &7&oRegister an expansion by the name of the file",
-				"&b/papi &funregister &9<expansion name>",
-				"  &7&oUnregister an expansion by name",
-				"&b/papi &fdump",
-					"  &7&oDump all relevant information needed to help debug issues into a paste link.");
-	}
+    Msg.msg(sender,
+        "&b&lPlaceholderAPI &8- &7Help Menu &8- &7(&f" + description.getVersion() + "&7)",
+        " ",
+        "&b/papi &fversion",
+        "  &7&oView plugin info/version",
+        "&b/papi &freload",
+        "  &7&oReload the config of PAPI",
+        "&b/papi &flist",
+        "  &7&oList active expansions",
+        "&b/papi &finfo &9<placeholder name>",
+        "  &7&oView information for a specific expansion",
+        "&b/papi &fparse &9<me/player name> <message>",
+        "  &7&oParse a message with placeholders",
+        "&b/papi &fbcparse &9<me/player name> <message>",
+        "  &7&oParse a message with placeholders and broadcast it",
+        "&b/papi &fparserel &9<player one> <player two> <message>",
+        "  &7&oParse a message with relational placeholders",
+        "&b/papi &fcmdparse &9<me/player> <command with placeholders>",
+        "  &7&oParse a message with relational placeholders",
+        "&b/papi &fregister &9<file name>",
+        "  &7&oRegister an expansion by the name of the file",
+        "&b/papi &funregister &9<expansion name>",
+        "  &7&oUnregister an expansion by name",
+        "&b/papi &fdump",
+          "  &7&oDump all relevant information needed to help debug issues into a paste link.");
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandInfo.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandInfo.java
@@ -34,87 +34,87 @@ import java.util.List;
 public final class CommandInfo extends PlaceholderCommand
 {
 
-	public CommandInfo()
-	{
-		super("info");
-	}
+  public CommandInfo()
+  {
+    super("info");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.isEmpty())
-		{
-			Msg.msg(sender,
-					"&cYou must specify the name of the expansion.");
-			return;
-		}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.isEmpty())
+    {
+      Msg.msg(sender,
+          "&cYou must specify the name of the expansion.");
+      return;
+    }
 
-		final PlaceholderExpansion expansion = plugin.getLocalExpansionManager().findExpansionByName(params.get(0)).orElse(null);
-		if (expansion == null)
-		{
-			Msg.msg(sender,
-					"&cThere is no expansion loaded with the identifier: &f" + params.get(0));
-			return;
-		}
+    final PlaceholderExpansion expansion = plugin.getLocalExpansionManager().findExpansionByName(params.get(0)).orElse(null);
+    if (expansion == null)
+    {
+      Msg.msg(sender,
+          "&cThere is no expansion loaded with the identifier: &f" + params.get(0));
+      return;
+    }
 
-		final StringBuilder builder = new StringBuilder();
+    final StringBuilder builder = new StringBuilder();
 
-		builder.append("&7Placeholder expansion info for: &r")
-			   .append(expansion.getName())
-			   .append('\n')
-			   .append("&7Status: &r")
-			   .append(expansion.isRegistered() ? "&aRegistered" : "7cNotRegistered")
-			   .append('\n');
+    builder.append("&7Placeholder expansion info for: &r")
+         .append(expansion.getName())
+         .append('\n')
+         .append("&7Status: &r")
+         .append(expansion.isRegistered() ? "&aRegistered" : "7cNotRegistered")
+         .append('\n');
 
-		final String author = expansion.getAuthor();
-		if (author != null)
-		{
-			builder.append("&7Author: &r")
-				   .append(author)
-				   .append('\n');
-		}
+    final String author = expansion.getAuthor();
+    if (author != null)
+    {
+      builder.append("&7Author: &r")
+           .append(author)
+           .append('\n');
+    }
 
-		final String version = expansion.getVersion();
-		if (version != null)
-		{
-			builder.append("&7Version: &r")
-				   .append(version)
-				   .append('\n');
-		}
+    final String version = expansion.getVersion();
+    if (version != null)
+    {
+      builder.append("&7Version: &r")
+           .append(version)
+           .append('\n');
+    }
 
-		final String requiredPlugin = expansion.getRequiredPlugin();
-		if (requiredPlugin != null)
-		{
-			builder.append("&7Requires plugin: &r")
-				   .append(requiredPlugin)
-				   .append('\n');
-		}
+    final String requiredPlugin = expansion.getRequiredPlugin();
+    if (requiredPlugin != null)
+    {
+      builder.append("&7Requires plugin: &r")
+           .append(requiredPlugin)
+           .append('\n');
+    }
 
-		final List<String> placeholders = expansion.getPlaceholders();
-		if (placeholders != null && !placeholders.isEmpty())
-		{
-			builder.append("&8&m-- &7Placeholders &8&m--&r")
-				   .append('\n');
+    final List<String> placeholders = expansion.getPlaceholders();
+    if (placeholders != null && !placeholders.isEmpty())
+    {
+      builder.append("&8&m-- &7Placeholders &8&m--&r")
+           .append('\n');
 
-			for (final String placeholder : placeholders)
-			{
-				builder.append(placeholder)
-					   .append('\n');
-			}
-		}
+      for (final String placeholder : placeholders)
+      {
+        builder.append(placeholder)
+             .append('\n');
+      }
+    }
 
-		Msg.msg(sender, builder.toString());
-	}
+    Msg.msg(sender, builder.toString());
+  }
 
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() > 1)
-		{
-			return;
-		}
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() > 1)
+    {
+      return;
+    }
 
-		suggestByParameter(PlaceholderAPI.getRegisteredIdentifiers().stream(), suggestions, params.isEmpty() ? null : params.get(0));
-	}
+    suggestByParameter(PlaceholderAPI.getRegisteredIdentifiers().stream(), suggestions, params.isEmpty() ? null : params.get(0));
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandList.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandList.java
@@ -36,27 +36,27 @@ import java.util.stream.Collectors;
 public final class CommandList extends PlaceholderCommand
 {
 
-	public CommandList()
-	{
-		super("list");
-	}
+  public CommandList()
+  {
+    super("list");
+  }
 
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		final Set<String> identifiers = PlaceholderAPI.getRegisteredIdentifiers();
-		if (identifiers.isEmpty())
-		{
-			Msg.msg(sender, "&cThere are no placeholder hooks active!");
-			return;
-		}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    final Set<String> identifiers = PlaceholderAPI.getRegisteredIdentifiers();
+    if (identifiers.isEmpty())
+    {
+      Msg.msg(sender, "&cThere are no placeholder hooks active!");
+      return;
+    }
 
-		final List<List<String>> partitions = Lists.partition(identifiers.stream().sorted().collect(Collectors.toList()), 10);
+    final List<List<String>> partitions = Lists.partition(identifiers.stream().sorted().collect(Collectors.toList()), 10);
 
-		Msg.msg(sender,
-				"&7A total of &f" + identifiers.size() + "&7 placeholder hook(s) are active: &a",
-				partitions.stream().map(partition -> String.join("&7, &a", partition)).collect(Collectors.joining("\n")));
-	}
+    Msg.msg(sender,
+        "&7A total of &f" + identifiers.size() + "&7 placeholder hook(s) are active: &a",
+        partitions.stream().map(partition -> String.join("&7, &a", partition)).collect(Collectors.joining("\n")));
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
@@ -44,200 +44,200 @@ import java.util.stream.Stream;
 public final class CommandParse extends PlaceholderCommand
 {
 
-	public CommandParse()
-	{
-		super("parse", "bcparse", "parserel", "cmdparse");
-	}
+  public CommandParse()
+  {
+    super("parse", "bcparse", "parserel", "cmdparse");
+  }
 
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		switch (alias.toLowerCase())
-		{
-			case "parserel":
-				evaluateParseRelation(sender, params);
-				break;
-			case "parse":
-				evaluateParseSingular(sender, params, false, false);
-				break;
-			case "bcparse":
-				evaluateParseSingular(sender, params, true, false);
-				break;
-			case "cmdparse":
-				evaluateParseSingular(sender, params, false, true);
-				break;
-		}
-	}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    switch (alias.toLowerCase())
+    {
+      case "parserel":
+        evaluateParseRelation(sender, params);
+        break;
+      case "parse":
+        evaluateParseSingular(sender, params, false, false);
+        break;
+      case "bcparse":
+        evaluateParseSingular(sender, params, true, false);
+        break;
+      case "cmdparse":
+        evaluateParseSingular(sender, params, false, true);
+        break;
+    }
+  }
 
-	@Override
-	public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		switch (alias.toLowerCase())
-		{
-			case "parserel":
-				completeParseRelation(params, suggestions);
-				break;
-			case "parse":
-			case "bcparse":
-			case "cmdparse":
-				completeParseSingular(sender, params, suggestions);
-				break;
-		}
-	}
-
-
-	private void evaluateParseSingular(@NotNull final CommandSender sender, @NotNull @Unmodifiable final List<String> params, final boolean broadcast, final boolean command)
-	{
-		if (params.size() < 2)
-		{
-			Msg.msg(sender, "&cYou must supply a target, and a message: &b/papi " + (broadcast ? "bcparse" : "parse") + " &7{target} &a{message}");
-			return;
-		}
-
-		@NotNull final OfflinePlayer player;
-
-		if ("me".equalsIgnoreCase(params.get(0)))
-		{
-			if (!(sender instanceof Player))
-			{
-				Msg.msg(sender, "&cYou must be a player to use &7me&c as a target!");
-				return;
-			}
-
-			player = ((Player) sender);
-		}
-		else
-		{
-			final OfflinePlayer target = resolvePlayer(params.get(0));
-			if (target == null)
-			{
-				Msg.msg(sender, "&cFailed to find player: &7" + params.get(0));
-				return;
-			}
-
-			player = target;
-		}
-
-		final String message = PlaceholderAPI.setPlaceholders(player, String.join(" ", params.subList(1, params.size())));
-
-		if (command)
-		{
-			Bukkit.dispatchCommand(sender, message);
-			return;
-		}
-
-		if (broadcast)
-		{
-			Msg.broadcast(message);
-		}
-		else
-		{
-			if (!(sender instanceof Player))
-			{
-				Msg.msg(sender, message);
-			}
-			else
-			{
-				((Player) sender).spigot().sendMessage(TextComponent.fromLegacyText(message));
-			}
-		}
-	}
-
-	private void evaluateParseRelation(@NotNull final CommandSender sender, @NotNull @Unmodifiable final List<String> params)
-	{
-		if (params.size() < 3)
-		{
-			Msg.msg(sender, "&cYou must supply two targets, and a message: &b/papi parserel &7{target one} {target two} &a{message}");
-			return;
-		}
-
-		final OfflinePlayer targetOne = resolvePlayer(params.get(0));
-		if (targetOne == null || !targetOne.isOnline())
-		{
-			Msg.msg(sender, "&cFailed to find player: &f" + params.get(0));
-			return;
-		}
-
-		final OfflinePlayer targetTwo = resolvePlayer(params.get(1));
-		if (targetTwo == null || !targetTwo.isOnline())
-		{
-			Msg.msg(sender, "&cFailed to find player: &f" + params.get(1));
-			return;
-		}
-
-		final String message = PlaceholderAPI.setRelationalPlaceholders(((Player) targetOne), ((Player) targetTwo), String.join(" ", params.subList(2, params.size())));
-		Msg.msg(sender, message);
-	}
+  @Override
+  public void complete(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    switch (alias.toLowerCase())
+    {
+      case "parserel":
+        completeParseRelation(params, suggestions);
+        break;
+      case "parse":
+      case "bcparse":
+      case "cmdparse":
+        completeParseSingular(sender, params, suggestions);
+        break;
+    }
+  }
 
 
-	private void completeParseSingular(@NotNull final CommandSender sender, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() <= 1)
-		{
-			if (sender instanceof Player && (params.isEmpty() || "me".startsWith(params.get(0).toLowerCase())))
-			{
-				suggestions.add("me");
-			}
+  private void evaluateParseSingular(@NotNull final CommandSender sender, @NotNull @Unmodifiable final List<String> params, final boolean broadcast, final boolean command)
+  {
+    if (params.size() < 2)
+    {
+      Msg.msg(sender, "&cYou must supply a target, and a message: &b/papi " + (broadcast ? "bcparse" : "parse") + " &7{target} &a{message}");
+      return;
+    }
 
-			final Stream<String> names = Bukkit.getOnlinePlayers().stream().map(Player::getName);
-			suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(0));
+    @NotNull final OfflinePlayer player;
 
-			return;
-		}
+    if ("me".equalsIgnoreCase(params.get(0)))
+    {
+      if (!(sender instanceof Player))
+      {
+        Msg.msg(sender, "&cYou must be a player to use &7me&c as a target!");
+        return;
+      }
 
-		final String name = params.get(params.size() - 1);
-		if (!name.startsWith("%") || name.endsWith("%"))
-		{
-			return;
-		}
+      player = ((Player) sender);
+    }
+    else
+    {
+      final OfflinePlayer target = resolvePlayer(params.get(0));
+      if (target == null)
+      {
+        Msg.msg(sender, "&cFailed to find player: &7" + params.get(0));
+        return;
+      }
 
-		final int index = name.indexOf('_');
-		if (index == -1)
-		{
-			return; // no arguments supplied yet
-		}
+      player = target;
+    }
 
-		final PlaceholderExpansion expansion = PlaceholderAPIPlugin.getInstance().getLocalExpansionManager().findExpansionByIdentifier(name.substring(1, index)).orElse(null);
-		if (expansion == null)
-		{
-			return;
-		}
+    final String message = PlaceholderAPI.setPlaceholders(player, String.join(" ", params.subList(1, params.size())));
 
-		final Set<String> possible = new HashSet<>(expansion.getPlaceholders());
+    if (command)
+    {
+      Bukkit.dispatchCommand(sender, message);
+      return;
+    }
 
-		PlaceholderAPIPlugin.getInstance()
-							.getCloudExpansionManager()
-							.findCloudExpansionByName(expansion.getName())
-							.ifPresent(cloud -> possible.addAll(cloud.getPlaceholders()));
+    if (broadcast)
+    {
+      Msg.broadcast(message);
+    }
+    else
+    {
+      if (!(sender instanceof Player))
+      {
+        Msg.msg(sender, message);
+      }
+      else
+      {
+        ((Player) sender).spigot().sendMessage(TextComponent.fromLegacyText(message));
+      }
+    }
+  }
 
-		suggestByParameter(possible.stream(), suggestions, params.get(params.size() - 1));
-	}
+  private void evaluateParseRelation(@NotNull final CommandSender sender, @NotNull @Unmodifiable final List<String> params)
+  {
+    if (params.size() < 3)
+    {
+      Msg.msg(sender, "&cYou must supply two targets, and a message: &b/papi parserel &7{target one} {target two} &a{message}");
+      return;
+    }
 
-	private void completeParseRelation(@NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
-	{
-		if (params.size() > 2)
-		{
-			return;
-		}
+    final OfflinePlayer targetOne = resolvePlayer(params.get(0));
+    if (targetOne == null || !targetOne.isOnline())
+    {
+      Msg.msg(sender, "&cFailed to find player: &f" + params.get(0));
+      return;
+    }
 
-		final Stream<String> names = Bukkit.getOnlinePlayers().stream().map(Player::getName);
-		suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(params.size() - 1));
-	}
+    final OfflinePlayer targetTwo = resolvePlayer(params.get(1));
+    if (targetTwo == null || !targetTwo.isOnline())
+    {
+      Msg.msg(sender, "&cFailed to find player: &f" + params.get(1));
+      return;
+    }
+
+    final String message = PlaceholderAPI.setRelationalPlaceholders(((Player) targetOne), ((Player) targetTwo), String.join(" ", params.subList(2, params.size())));
+    Msg.msg(sender, message);
+  }
 
 
-	@Nullable
-	private OfflinePlayer resolvePlayer(@NotNull final String name)
-	{
-		OfflinePlayer target = Bukkit.getPlayer(name);
+  private void completeParseSingular(@NotNull final CommandSender sender, @NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() <= 1)
+    {
+      if (sender instanceof Player && (params.isEmpty() || "me".startsWith(params.get(0).toLowerCase())))
+      {
+        suggestions.add("me");
+      }
 
-		if (target == null)
-		{
-			target = Bukkit.getOfflinePlayer(name); // this is probably not a great idea.
-		}
+      final Stream<String> names = Bukkit.getOnlinePlayers().stream().map(Player::getName);
+      suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(0));
 
-		return target.hasPlayedBefore() ? target : null;
+      return;
+    }
 
-	}
+    final String name = params.get(params.size() - 1);
+    if (!name.startsWith("%") || name.endsWith("%"))
+    {
+      return;
+    }
+
+    final int index = name.indexOf('_');
+    if (index == -1)
+    {
+      return; // no arguments supplied yet
+    }
+
+    final PlaceholderExpansion expansion = PlaceholderAPIPlugin.getInstance().getLocalExpansionManager().findExpansionByIdentifier(name.substring(1, index)).orElse(null);
+    if (expansion == null)
+    {
+      return;
+    }
+
+    final Set<String> possible = new HashSet<>(expansion.getPlaceholders());
+
+    PlaceholderAPIPlugin.getInstance()
+              .getCloudExpansionManager()
+              .findCloudExpansionByName(expansion.getName())
+              .ifPresent(cloud -> possible.addAll(cloud.getPlaceholders()));
+
+    suggestByParameter(possible.stream(), suggestions, params.get(params.size() - 1));
+  }
+
+  private void completeParseRelation(@NotNull @Unmodifiable final List<String> params, @NotNull final List<String> suggestions)
+  {
+    if (params.size() > 2)
+    {
+      return;
+    }
+
+    final Stream<String> names = Bukkit.getOnlinePlayers().stream().map(Player::getName);
+    suggestByParameter(names, suggestions, params.isEmpty() ? null : params.get(params.size() - 1));
+  }
+
+
+  @Nullable
+  private OfflinePlayer resolvePlayer(@NotNull final String name)
+  {
+    OfflinePlayer target = Bukkit.getPlayer(name);
+
+    if (target == null)
+    {
+      target = Bukkit.getOfflinePlayer(name); // this is probably not a great idea.
+    }
+
+    return target.hasPlayedBefore() ? target : null;
+
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandReload.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandReload.java
@@ -31,15 +31,15 @@ import java.util.List;
 public final class CommandReload extends PlaceholderCommand
 {
 
-	public CommandReload()
-	{
-		super("reload");
-	}
+  public CommandReload()
+  {
+    super("reload");
+  }
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		plugin.reloadConf(sender);
-	}
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    plugin.reloadConf(sender);
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandVersion.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandVersion.java
@@ -33,22 +33,22 @@ import java.util.List;
 public final class CommandVersion extends PlaceholderCommand
 {
 
-	public CommandVersion()
-	{
-		super("version");
-	}
+  public CommandVersion()
+  {
+    super("version");
+  }
 
 
-	@Override
-	public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
-	{
-		final PluginDescriptionFile description = plugin.getDescription();
+  @Override
+  public void evaluate(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final CommandSender sender, @NotNull final String alias, @NotNull @Unmodifiable final List<String> params)
+  {
+    final PluginDescriptionFile description = plugin.getDescription();
 
-		Msg.msg(sender,
-				"&b&lPlaceholderAPI &7(&f" + description.getVersion() + "&7)",
-				"&7Author: &f" + description.getAuthors(),
-				"&7PAPI Commands: &b/papi &fhelp",
-				"&7eCloud Commands&8: &b/papi &fecloud");
-	}
+    Msg.msg(sender,
+        "&b&lPlaceholderAPI &7(&f" + description.getVersion() + "&7)",
+        "&7Author: &f" + description.getAuthors(),
+        "&7PAPI Commands: &b/papi &fhelp",
+        "&7eCloud Commands&8: &b/papi &fecloud");
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/configuration/ExpansionSort.java
+++ b/src/main/java/me/clip/placeholderapi/configuration/ExpansionSort.java
@@ -28,24 +28,24 @@ import java.util.Comparator;
 public enum ExpansionSort implements Comparator<CloudExpansion>
 {
 
-	NAME(Comparator.comparing(CloudExpansion::getName)),
-	AUTHOR(Comparator.comparing(CloudExpansion::getAuthor)),
-	LATEST(Comparator.comparing(CloudExpansion::getLastUpdate).reversed());
+  NAME(Comparator.comparing(CloudExpansion::getName)),
+  AUTHOR(Comparator.comparing(CloudExpansion::getAuthor)),
+  LATEST(Comparator.comparing(CloudExpansion::getLastUpdate).reversed());
 
 
-	@NotNull
-	private final Comparator<CloudExpansion> comparator;
+  @NotNull
+  private final Comparator<CloudExpansion> comparator;
 
-	ExpansionSort(@NotNull final Comparator<CloudExpansion> comparator)
-	{
-		this.comparator = comparator;
-	}
+  ExpansionSort(@NotNull final Comparator<CloudExpansion> comparator)
+  {
+    this.comparator = comparator;
+  }
 
 
-	@Override
-	public final int compare(final CloudExpansion expansion1, final CloudExpansion expansion2)
-	{
-		return comparator.compare(expansion1, expansion2);
-	}
+  @Override
+  public final int compare(final CloudExpansion expansion1, final CloudExpansion expansion2)
+  {
+    return comparator.compare(expansion1, expansion2);
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/configuration/PlaceholderAPIConfig.java
+++ b/src/main/java/me/clip/placeholderapi/configuration/PlaceholderAPIConfig.java
@@ -28,80 +28,80 @@ import java.util.Optional;
 public final class PlaceholderAPIConfig
 {
 
-	@NotNull
-	private final PlaceholderAPIPlugin plugin;
+  @NotNull
+  private final PlaceholderAPIPlugin plugin;
 
-	public PlaceholderAPIConfig(@NotNull final PlaceholderAPIPlugin plugin)
-	{
-		this.plugin = plugin;
-	}
-
-
-	public boolean checkUpdates()
-	{
-		return plugin.getConfig().getBoolean("check_updates");
-	}
-
-	public boolean cloudAllowUnverifiedExpansions()
-	{
-		return plugin.getConfig().getBoolean("cloud_allow_unverified_expansions");
-	}
+  public PlaceholderAPIConfig(@NotNull final PlaceholderAPIPlugin plugin)
+  {
+    this.plugin = plugin;
+  }
 
 
-	public boolean isCloudEnabled()
-	{
-		return plugin.getConfig().getBoolean("cloud_enabled");
-	}
+  public boolean checkUpdates()
+  {
+    return plugin.getConfig().getBoolean("check_updates");
+  }
 
-	public void setCloudEnabled(boolean state)
-	{
-		plugin.getConfig().set("cloud_enabled", state);
-		plugin.saveConfig();
-	}
-
-
-	public boolean isDebugMode()
-	{
-		return plugin.getConfig().getBoolean("debug", false);
-	}
+  public boolean cloudAllowUnverifiedExpansions()
+  {
+    return plugin.getConfig().getBoolean("cloud_allow_unverified_expansions");
+  }
 
 
-	public Optional<ExpansionSort> getExpansionSort()
-	{
-		final String option = plugin.getConfig().getString("cloud_sorting", ExpansionSort.LATEST.name());
+  public boolean isCloudEnabled()
+  {
+    return plugin.getConfig().getBoolean("cloud_enabled");
+  }
 
-		try
-		{
-			//noinspection ConstantConditions (bad spigot annotation)
-			return Optional.of(ExpansionSort.valueOf(option.toUpperCase()));
-		}
-		catch (final IllegalArgumentException ignored)
-		{
-			return Optional.empty();
-		}
-	}
+  public void setCloudEnabled(boolean state)
+  {
+    plugin.getConfig().set("cloud_enabled", state);
+    plugin.saveConfig();
+  }
 
 
-	@NotNull
-	public String dateFormat()
-	{
-		//noinspection ConstantConditions (bad spigot annotation)
-		return plugin.getConfig().getString("date_format", "MM/dd/yy HH:mm:ss");
-	}
+  public boolean isDebugMode()
+  {
+    return plugin.getConfig().getBoolean("debug", false);
+  }
 
 
-	@NotNull
-	public String booleanTrue()
-	{
-		//noinspection ConstantConditions (bad spigot annotation)
-		return plugin.getConfig().getString("boolean.true", "true");
-	}
+  public Optional<ExpansionSort> getExpansionSort()
+  {
+    final String option = plugin.getConfig().getString("cloud_sorting", ExpansionSort.LATEST.name());
 
-	@NotNull
-	public String booleanFalse()
-	{
-		//noinspection ConstantConditions (bad spigot annotation)
-		return plugin.getConfig().getString("boolean.false", "false");
-	}
+    try
+    {
+      //noinspection ConstantConditions (bad spigot annotation)
+      return Optional.of(ExpansionSort.valueOf(option.toUpperCase()));
+    }
+    catch (final IllegalArgumentException ignored)
+    {
+      return Optional.empty();
+    }
+  }
+
+
+  @NotNull
+  public String dateFormat()
+  {
+    //noinspection ConstantConditions (bad spigot annotation)
+    return plugin.getConfig().getString("date_format", "MM/dd/yy HH:mm:ss");
+  }
+
+
+  @NotNull
+  public String booleanTrue()
+  {
+    //noinspection ConstantConditions (bad spigot annotation)
+    return plugin.getConfig().getString("boolean.true", "true");
+  }
+
+  @NotNull
+  public String booleanFalse()
+  {
+    //noinspection ConstantConditions (bad spigot annotation)
+    return plugin.getConfig().getString("boolean.false", "false");
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/events/ExpansionRegisterEvent.java
+++ b/src/main/java/me/clip/placeholderapi/events/ExpansionRegisterEvent.java
@@ -29,52 +29,52 @@ import org.jetbrains.annotations.NotNull;
 public final class ExpansionRegisterEvent extends Event implements Cancellable
 {
 
-	@NotNull
-	private static final HandlerList HANDLERS = new HandlerList();
+  @NotNull
+  private static final HandlerList HANDLERS = new HandlerList();
 
 
-	private       boolean              cancelled;
-	@NotNull
-	private final PlaceholderExpansion expansion;
+  private       boolean              cancelled;
+  @NotNull
+  private final PlaceholderExpansion expansion;
 
-	public ExpansionRegisterEvent(@NotNull final PlaceholderExpansion expansion)
-	{
-		this.expansion = expansion;
-	}
-
-
-	@NotNull
-	public PlaceholderExpansion getExpansion()
-	{
-		return expansion;
-	}
+  public ExpansionRegisterEvent(@NotNull final PlaceholderExpansion expansion)
+  {
+    this.expansion = expansion;
+  }
 
 
-	@Override
-	public boolean isCancelled()
-	{
-		return cancelled;
-	}
-
-	@Override
-	public void setCancelled(boolean cancelled)
-	{
-		this.cancelled = cancelled;
-	}
+  @NotNull
+  public PlaceholderExpansion getExpansion()
+  {
+    return expansion;
+  }
 
 
-	@NotNull
-	@Override
-	public HandlerList getHandlers()
-	{
-		return HANDLERS;
-	}
+  @Override
+  public boolean isCancelled()
+  {
+    return cancelled;
+  }
+
+  @Override
+  public void setCancelled(boolean cancelled)
+  {
+    this.cancelled = cancelled;
+  }
 
 
-	@NotNull
-	public static HandlerList getHandlerList()
-	{
-		return HANDLERS;
-	}
+  @NotNull
+  @Override
+  public HandlerList getHandlers()
+  {
+    return HANDLERS;
+  }
+
+
+  @NotNull
+  public static HandlerList getHandlerList()
+  {
+    return HANDLERS;
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/events/ExpansionUnregisterEvent.java
+++ b/src/main/java/me/clip/placeholderapi/events/ExpansionUnregisterEvent.java
@@ -28,38 +28,38 @@ import org.jetbrains.annotations.NotNull;
 public final class ExpansionUnregisterEvent extends Event
 {
 
-	@NotNull
-	private static final HandlerList HANDLERS = new HandlerList();
+  @NotNull
+  private static final HandlerList HANDLERS = new HandlerList();
 
 
-	@NotNull
-	private final PlaceholderExpansion expansion;
+  @NotNull
+  private final PlaceholderExpansion expansion;
 
-	public ExpansionUnregisterEvent(@NotNull final PlaceholderExpansion expansion)
-	{
-		this.expansion = expansion;
-	}
-
-
-	@NotNull
-	public PlaceholderExpansion getExpansion()
-	{
-		return expansion;
-	}
+  public ExpansionUnregisterEvent(@NotNull final PlaceholderExpansion expansion)
+  {
+    this.expansion = expansion;
+  }
 
 
-	@NotNull
-	@Override
-	public HandlerList getHandlers()
-	{
-		return HANDLERS;
-	}
+  @NotNull
+  public PlaceholderExpansion getExpansion()
+  {
+    return expansion;
+  }
 
 
-	@NotNull
-	public static HandlerList getHandlerList()
-	{
-		return HANDLERS;
-	}
+  @NotNull
+  @Override
+  public HandlerList getHandlers()
+  {
+    return HANDLERS;
+  }
+
+
+  @NotNull
+  public static HandlerList getHandlerList()
+  {
+    return HANDLERS;
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/events/PlaceholderHookUnloadEvent.java
+++ b/src/main/java/me/clip/placeholderapi/events/PlaceholderHookUnloadEvent.java
@@ -32,46 +32,46 @@ import org.jetbrains.annotations.NotNull;
 public final class PlaceholderHookUnloadEvent extends Event
 {
 
-	@NotNull
-	private static final HandlerList HANDLERS = new HandlerList();
+  @NotNull
+  private static final HandlerList HANDLERS = new HandlerList();
 
 
-	@NotNull
-	private final String          plugin;
-	@NotNull
-	private final PlaceholderHook placeholderHook;
+  @NotNull
+  private final String          plugin;
+  @NotNull
+  private final PlaceholderHook placeholderHook;
 
-	public PlaceholderHookUnloadEvent(@NotNull final String plugin, @NotNull final PlaceholderHook placeholderHook)
-	{
-		this.plugin          = plugin;
-		this.placeholderHook = placeholderHook;
-	}
+  public PlaceholderHookUnloadEvent(@NotNull final String plugin, @NotNull final PlaceholderHook placeholderHook)
+  {
+    this.plugin          = plugin;
+    this.placeholderHook = placeholderHook;
+  }
 
-	@NotNull
-	public String getHookName()
-	{
-		return plugin;
-	}
+  @NotNull
+  public String getHookName()
+  {
+    return plugin;
+  }
 
-	@NotNull
-	public PlaceholderHook getHook()
-	{
-		return placeholderHook;
-	}
-
-
-	@NotNull
-	@Override
-	public HandlerList getHandlers()
-	{
-		return HANDLERS;
-	}
+  @NotNull
+  public PlaceholderHook getHook()
+  {
+    return placeholderHook;
+  }
 
 
-	@NotNull
-	public static HandlerList getHandlerList()
-	{
-		return HANDLERS;
-	}
+  @NotNull
+  @Override
+  public HandlerList getHandlers()
+  {
+    return HANDLERS;
+  }
+
+
+  @NotNull
+  public static HandlerList getHandlerList()
+  {
+    return HANDLERS;
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/exceptions/NoDefaultCommandException.java
+++ b/src/main/java/me/clip/placeholderapi/exceptions/NoDefaultCommandException.java
@@ -20,7 +20,7 @@
 
 package me.clip.placeholderapi.exceptions;
 
-public final class NoDefaultCommandException extends RuntimeException {
+public final class NoDefaultCommandException extends RuntimeException { 
     public NoDefaultCommandException(final String message) {
         super(message);
     }

--- a/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
@@ -37,263 +37,263 @@ import java.util.Objects;
 public abstract class PlaceholderExpansion extends PlaceholderHook
 {
 
-	/**
-	 * The placeholder identifier of this expansion
-	 *
-	 * @return placeholder identifier that is associated with this expansion
-	 */
-	@NotNull
-	public abstract String getIdentifier();
+  /**
+   * The placeholder identifier of this expansion
+   *
+   * @return placeholder identifier that is associated with this expansion
+   */
+  @NotNull
+  public abstract String getIdentifier();
 
-	/**
-	 * The author of this expansion
-	 *
-	 * @return name of the author for this expansion
-	 */
-	@NotNull
-	public abstract String getAuthor();
+  /**
+   * The author of this expansion
+   *
+   * @return name of the author for this expansion
+   */
+  @NotNull
+  public abstract String getAuthor();
 
-	/**
-	 * The version of this expansion
-	 *
-	 * @return current version of this expansion
-	 */
-	@NotNull
-	public abstract String getVersion();
+  /**
+   * The version of this expansion
+   *
+   * @return current version of this expansion
+   */
+  @NotNull
+  public abstract String getVersion();
 
-	@Nullable
-	@Override /* override for now >:) */
-	public String onRequest(@Nullable final OfflinePlayer player, @NotNull final String params)
-	{
-		return super.onRequest(player, params);
-	}
-
-
-	/**
-	 * The name of this expansion
-	 *
-	 * @return {@link #getIdentifier()} by default, name of this expansion if specified
-	 */
-	@NotNull
-	public String getName()
-	{
-		return getIdentifier();
-	}
-
-	/**
-	 * The name of the plugin that this expansion hooks into. by default will null
-	 *
-	 * @return plugin name that this expansion requires to function
-	 */
-	@Nullable
-	public String getRequiredPlugin()
-	{
-		return getPlugin();
-	}
-
-	/**
-	 * The placeholders associated with this expansion
-	 *
-	 * @return placeholder list that this expansion provides
-	 */
-	@NotNull
-	public List<String> getPlaceholders()
-	{
-		return Collections.emptyList();
-	}
+  @Nullable
+  @Override /* override for now >:) */
+  public String onRequest(@Nullable final OfflinePlayer player, @NotNull final String params)
+  {
+    return super.onRequest(player, params);
+  }
 
 
-	/**
-	 * Expansions that do not use the ecloud and instead register from the dependency should set this
-	 * to true to ensure that your placeholder expansion is not unregistered when the papi reload
-	 * command is used
-	 *
-	 * @return if this expansion should persist through placeholder reloads
-	 */
-	public boolean persist()
-	{
-		return false;
-	}
+  /**
+   * The name of this expansion
+   *
+   * @return {@link #getIdentifier()} by default, name of this expansion if specified
+   */
+  @NotNull
+  public String getName()
+  {
+    return getIdentifier();
+  }
+
+  /**
+   * The name of the plugin that this expansion hooks into. by default will null
+   *
+   * @return plugin name that this expansion requires to function
+   */
+  @Nullable
+  public String getRequiredPlugin()
+  {
+    return getPlugin();
+  }
+
+  /**
+   * The placeholders associated with this expansion
+   *
+   * @return placeholder list that this expansion provides
+   */
+  @NotNull
+  public List<String> getPlaceholders()
+  {
+    return Collections.emptyList();
+  }
 
 
-	/**
-	 * Check if this placeholder identifier has already been registered
-	 *
-	 * @return true if the identifier for this expansion is already registered
-	 */
-	public final boolean isRegistered()
-	{
-		return getPlaceholderAPI().getLocalExpansionManager().findExpansionByIdentifier(getIdentifier()).map(it -> it.equals(this)).orElse(false);
-	}
+  /**
+   * Expansions that do not use the ecloud and instead register from the dependency should set this
+   * to true to ensure that your placeholder expansion is not unregistered when the papi reload
+   * command is used
+   *
+   * @return if this expansion should persist through placeholder reloads
+   */
+  public boolean persist()
+  {
+    return false;
+  }
 
 
-	/**
-	 * If any requirements need to be checked before this expansion should register, you can check
-	 * them here
-	 *
-	 * @return true if this hook meets all the requirements to register
-	 */
-	public boolean canRegister()
-	{
-		return getRequiredPlugin() == null || Bukkit.getPluginManager().getPlugin(getRequiredPlugin()) != null;
-	}
-
-	/**
-	 * Attempt to register this PlaceholderExpansion
-	 *
-	 * @return true if this expansion is now registered with PlaceholderAPI
-	 */
-	public boolean register()
-	{
-		return canRegister() && getPlaceholderAPI().getLocalExpansionManager().register(this);
-	}
-
-	/**
-	 * Attempt to unregister this PlaceholderExpansion
-	 *
-	 * @return true if this expansion is now unregistered with PlaceholderAPI
-	 */
-	public final boolean unregister()
-	{
-		return getPlaceholderAPI().getLocalExpansionManager().unregister(this);
-	}
+  /**
+   * Check if this placeholder identifier has already been registered
+   *
+   * @return true if the identifier for this expansion is already registered
+   */
+  public final boolean isRegistered()
+  {
+    return getPlaceholderAPI().getLocalExpansionManager().findExpansionByIdentifier(getIdentifier()).map(it -> it.equals(this)).orElse(false);
+  }
 
 
-	/**
-	 * Quick getter for the {@link PlaceholderAPIPlugin} instance
-	 *
-	 * @return {@link PlaceholderAPIPlugin} instance
-	 */
-	@NotNull
-	public final PlaceholderAPIPlugin getPlaceholderAPI()
-	{
-		return PlaceholderAPIPlugin.getInstance();
-	}
+  /**
+   * If any requirements need to be checked before this expansion should register, you can check
+   * them here
+   *
+   * @return true if this hook meets all the requirements to register
+   */
+  public boolean canRegister()
+  {
+    return getRequiredPlugin() == null || Bukkit.getPluginManager().getPlugin(getRequiredPlugin()) != null;
+  }
+
+  /**
+   * Attempt to register this PlaceholderExpansion
+   *
+   * @return true if this expansion is now registered with PlaceholderAPI
+   */
+  public boolean register()
+  {
+    return canRegister() && getPlaceholderAPI().getLocalExpansionManager().register(this);
+  }
+
+  /**
+   * Attempt to unregister this PlaceholderExpansion
+   *
+   * @return true if this expansion is now unregistered with PlaceholderAPI
+   */
+  public final boolean unregister()
+  {
+    return getPlaceholderAPI().getLocalExpansionManager().unregister(this);
+  }
 
 
-	// === Configuration ===
+  /**
+   * Quick getter for the {@link PlaceholderAPIPlugin} instance
+   *
+   * @return {@link PlaceholderAPIPlugin} instance
+   */
+  @NotNull
+  public final PlaceholderAPIPlugin getPlaceholderAPI()
+  {
+    return PlaceholderAPIPlugin.getInstance();
+  }
 
-	@Nullable
-	public final ConfigurationSection getConfigSection()
-	{
-		return getPlaceholderAPI().getConfig().getConfigurationSection("expansions." + getIdentifier());
-	}
 
-	@Nullable
-	public final ConfigurationSection getConfigSection(@NotNull final String path)
-	{
-		final ConfigurationSection section = getConfigSection();
-		return section == null ? null : section.getConfigurationSection(path);
-	}
+  // === Configuration ===
 
-	@Nullable
-	@Contract("_, !null -> !null")
-	public final Object get(@NotNull final String path, final Object def)
-	{
-		final ConfigurationSection section = getConfigSection();
-		return section == null ? def : section.get(path, def);
-	}
+  @Nullable
+  public final ConfigurationSection getConfigSection()
+  {
+    return getPlaceholderAPI().getConfig().getConfigurationSection("expansions." + getIdentifier());
+  }
 
-	public final int getInt(@NotNull final String path, final int def)
-	{
-		final ConfigurationSection section = getConfigSection();
-		return section == null ? def : section.getInt(path, def);
-	}
+  @Nullable
+  public final ConfigurationSection getConfigSection(@NotNull final String path)
+  {
+    final ConfigurationSection section = getConfigSection();
+    return section == null ? null : section.getConfigurationSection(path);
+  }
 
-	public final long getLong(@NotNull final String path, final long def)
-	{
-		final ConfigurationSection section = getConfigSection();
-		return section == null ? def : section.getLong(path, def);
-	}
+  @Nullable
+  @Contract("_, !null -> !null")
+  public final Object get(@NotNull final String path, final Object def)
+  {
+    final ConfigurationSection section = getConfigSection();
+    return section == null ? def : section.get(path, def);
+  }
 
-	public final double getDouble(@NotNull final String path, final double def)
-	{
-		final ConfigurationSection section = getConfigSection();
-		return section == null ? def : section.getDouble(path, def);
-	}
+  public final int getInt(@NotNull final String path, final int def)
+  {
+    final ConfigurationSection section = getConfigSection();
+    return section == null ? def : section.getInt(path, def);
+  }
 
-	@Nullable
-	@Contract("_, !null -> !null")
-	public final String getString(@NotNull final String path, @Nullable final String def)
-	{
-		final ConfigurationSection section = getConfigSection();
-		return section == null ? def : section.getString(path, def);
-	}
+  public final long getLong(@NotNull final String path, final long def)
+  {
+    final ConfigurationSection section = getConfigSection();
+    return section == null ? def : section.getLong(path, def);
+  }
 
-	@NotNull
-	public final List<String> getStringList(@NotNull final String path)
-	{
-		final ConfigurationSection section = getConfigSection();
-		return section == null ? Collections.emptyList() : section.getStringList(path);
-	}
+  public final double getDouble(@NotNull final String path, final double def)
+  {
+    final ConfigurationSection section = getConfigSection();
+    return section == null ? def : section.getDouble(path, def);
+  }
 
-	public final boolean configurationContains(@NotNull final String path)
-	{
-		final ConfigurationSection section = getConfigSection();
-		return section != null && section.contains(path);
-	}
+  @Nullable
+  @Contract("_, !null -> !null")
+  public final String getString(@NotNull final String path, @Nullable final String def)
+  {
+    final ConfigurationSection section = getConfigSection();
+    return section == null ? def : section.getString(path, def);
+  }
 
-	@Override
-	public final boolean equals(final Object o)
-	{
-		if (this == o)
-		{
-			return true;
-		}
-		if (!(o instanceof PlaceholderExpansion))
-		{
-			return false;
-		}
+  @NotNull
+  public final List<String> getStringList(@NotNull final String path)
+  {
+    final ConfigurationSection section = getConfigSection();
+    return section == null ? Collections.emptyList() : section.getStringList(path);
+  }
 
-		final PlaceholderExpansion expansion = (PlaceholderExpansion) o;
+  public final boolean configurationContains(@NotNull final String path)
+  {
+    final ConfigurationSection section = getConfigSection();
+    return section != null && section.contains(path);
+  }
 
-		return getIdentifier().equals(expansion.getIdentifier()) &&
-			   getAuthor().equals(expansion.getAuthor()) &&
-			   getVersion().equals(expansion.getVersion());
-	}
+  @Override
+  public final boolean equals(final Object o)
+  {
+    if (this == o)
+    {
+      return true;
+    }
+    if (!(o instanceof PlaceholderExpansion))
+    {
+      return false;
+    }
 
-	@Override
-	public final int hashCode()
-	{
-		return Objects.hash(getIdentifier(), getAuthor(), getVersion());
-	}
+    final PlaceholderExpansion expansion = (PlaceholderExpansion) o;
 
-	@Override
-	public final String toString()
-	{
-		return String.format("PlaceholderExpansion[name: '%s', author: '%s', version: '%s']", getName(), getAuthor(), getVersion());
-	}
+    return getIdentifier().equals(expansion.getIdentifier()) &&
+         getAuthor().equals(expansion.getAuthor()) &&
+         getVersion().equals(expansion.getVersion());
+  }
 
-	// === Deprecated API ===
+  @Override
+  public final int hashCode()
+  {
+    return Objects.hash(getIdentifier(), getAuthor(), getVersion());
+  }
 
-	/**
-	 * @deprecated As of versions greater than 2.8.7, use {@link #getRequiredPlugin()}
-	 */
-	@Deprecated
-	@ApiStatus.ScheduledForRemoval(inVersion = "2.11.0")
-	public String getPlugin()
-	{
-		return null;
-	}
+  @Override
+  public final String toString()
+  {
+    return String.format("PlaceholderExpansion[name: '%s', author: '%s', version: '%s']", getName(), getAuthor(), getVersion());
+  }
 
-	/**
-	 * @deprecated As of versions greater than 2.8.7, use the expansion cloud to show a description
-	 */
-	@Deprecated
-	@ApiStatus.ScheduledForRemoval(inVersion = "2.11.0")
-	public String getDescription()
-	{
-		return null;
-	}
+  // === Deprecated API ===
 
-	/**
-	 * @deprecated As of versions greater than 2.8.7, use the expansion cloud to display a link
-	 */
-	@Deprecated
-	@ApiStatus.ScheduledForRemoval(inVersion = "2.11.0")
-	public String getLink()
-	{
-		return null;
-	}
+  /**
+   * @deprecated As of versions greater than 2.8.7, use {@link #getRequiredPlugin()}
+   */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "2.11.0")
+  public String getPlugin()
+  {
+    return null;
+  }
+
+  /**
+   * @deprecated As of versions greater than 2.8.7, use the expansion cloud to show a description
+   */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "2.11.0")
+  public String getDescription()
+  {
+    return null;
+  }
+
+  /**
+   * @deprecated As of versions greater than 2.8.7, use the expansion cloud to display a link
+   */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "2.11.0")
+  public String getLink()
+  {
+    return null;
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/CloudExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/CloudExpansionManager.java
@@ -50,239 +50,239 @@ import java.util.stream.Collectors;
 public final class CloudExpansionManager
 {
 
-	@NotNull
-	private static final String API_URL = "http://api.extendedclip.com/v2/";
+  @NotNull
+  private static final String API_URL = "http://api.extendedclip.com/v2/";
 
-	@NotNull
-	private static final Gson GSON = new Gson();
-	@NotNull
-	private static final Type TYPE = new TypeToken<Map<String, CloudExpansion>>() {}.getType();
+  @NotNull
+  private static final Gson GSON = new Gson();
+  @NotNull
+  private static final Type TYPE = new TypeToken<Map<String, CloudExpansion>>() {}.getType();
 
-	@NotNull
-	private final Collector<CloudExpansion, ?, Map<String, CloudExpansion>> INDEXED_NAME_COLLECTOR = Collectors.toMap(CloudExpansionManager::toIndexName, Function.identity());
-
-
-	@NotNull
-	private final PlaceholderAPIPlugin plugin;
-
-	@NotNull
-	private final Map<String, CloudExpansion>          cache = new HashMap<>();
-	@NotNull
-	private final Map<String, CompletableFuture<File>> await = new ConcurrentHashMap<>();
+  @NotNull
+  private final Collector<CloudExpansion, ?, Map<String, CloudExpansion>> INDEXED_NAME_COLLECTOR = Collectors.toMap(CloudExpansionManager::toIndexName, Function.identity());
 
 
-	public CloudExpansionManager(@NotNull final PlaceholderAPIPlugin plugin)
-	{
-		this.plugin = plugin;
-	}
+  @NotNull
+  private final PlaceholderAPIPlugin plugin;
+
+  @NotNull
+  private final Map<String, CloudExpansion>          cache = new HashMap<>();
+  @NotNull
+  private final Map<String, CompletableFuture<File>> await = new ConcurrentHashMap<>();
 
 
-	public void load()
-	{
-		clean();
-		fetch(plugin.getPlaceholderAPIConfig().cloudAllowUnverifiedExpansions());
-	}
-
-	public void kill()
-	{
-		clean();
-	}
+  public CloudExpansionManager(@NotNull final PlaceholderAPIPlugin plugin)
+  {
+    this.plugin = plugin;
+  }
 
 
-	@NotNull
-	@Unmodifiable
-	public Map<String, CloudExpansion> getCloudExpansions()
-	{
-		return ImmutableMap.copyOf(cache);
-	}
+  public void load()
+  {
+    clean();
+    fetch(plugin.getPlaceholderAPIConfig().cloudAllowUnverifiedExpansions());
+  }
 
-	@NotNull
-	@Unmodifiable
-	public Map<String, CloudExpansion> getCloudExpansionsInstalled()
-	{
-		if (cache.isEmpty())
-		{
-			return Collections.emptyMap();
-		}
-
-		return cache.values()
-					.stream()
-					.filter(CloudExpansion::hasExpansion)
-					.collect(INDEXED_NAME_COLLECTOR);
-	}
-
-	@NotNull
-	@Unmodifiable
-	public Map<String, CloudExpansion> getCloudExpansionsByAuthor(@NotNull final String author)
-	{
-		if (cache.isEmpty())
-		{
-			return Collections.emptyMap();
-		}
-
-		return cache.values()
-					.stream()
-					.filter(expansion -> author.equalsIgnoreCase(expansion.getAuthor()))
-					.collect(INDEXED_NAME_COLLECTOR);
-	}
-
-	@NotNull
-	@Unmodifiable
-	public Set<String> getCloudExpansionAuthors()
-	{
-		return cache.values().stream().map(CloudExpansion::getAuthor).collect(Collectors.toSet());
-	}
+  public void kill()
+  {
+    clean();
+  }
 
 
-	public int getCloudExpansionAuthorCount()
-	{
-		return getCloudExpansionAuthors().size();
-	}
+  @NotNull
+  @Unmodifiable
+  public Map<String, CloudExpansion> getCloudExpansions()
+  {
+    return ImmutableMap.copyOf(cache);
+  }
 
-	public int getCloudUpdateCount()
-	{
-		return ((int) plugin.getLocalExpansionManager()
-							.getExpansions()
-							.stream()
-							.filter(expansion -> findCloudExpansionByName(expansion.getName()).map(CloudExpansion::shouldUpdate).orElse(false))
-							.count());
-	}
+  @NotNull
+  @Unmodifiable
+  public Map<String, CloudExpansion> getCloudExpansionsInstalled()
+  {
+    if (cache.isEmpty())
+    {
+      return Collections.emptyMap();
+    }
 
+    return cache.values()
+          .stream()
+          .filter(CloudExpansion::hasExpansion)
+          .collect(INDEXED_NAME_COLLECTOR);
+  }
 
-	@NotNull
-	public Optional<CloudExpansion> findCloudExpansionByName(@NotNull final String name)
-	{
-		return Optional.ofNullable(cache.get(toIndexName(name)));
-	}
+  @NotNull
+  @Unmodifiable
+  public Map<String, CloudExpansion> getCloudExpansionsByAuthor(@NotNull final String author)
+  {
+    if (cache.isEmpty())
+    {
+      return Collections.emptyMap();
+    }
 
+    return cache.values()
+          .stream()
+          .filter(expansion -> author.equalsIgnoreCase(expansion.getAuthor()))
+          .collect(INDEXED_NAME_COLLECTOR);
+  }
 
-	public void clean()
-	{
-		cache.clear();
-
-		await.values().forEach(future -> future.cancel(true));
-		await.clear();
-	}
-
-	public void fetch(final boolean allowUnverified)
-	{
-		plugin.getLogger().info("Fetching available expansion information...");
-
-		CompletableFuture<Map<String, CloudExpansion>> future = CompletableFuture.supplyAsync(() -> {
-			final Map<String, CloudExpansion> values = new HashMap<>();
-
-			try
-			{
-				//noinspection UnstableApiUsage
-				final String json = Resources.toString(new URL(API_URL), StandardCharsets.UTF_8);
-				values.putAll(GSON.fromJson(json, TYPE));
-			}
-			catch (final IOException ex)
-			{
-				throw new CompletionException(ex);
-			}
-
-			values.values().removeIf(value -> value.getLatestVersion() == null || value.getVersion(value.getLatestVersion()) == null);
-
-			return values;
-		});
+  @NotNull
+  @Unmodifiable
+  public Set<String> getCloudExpansionAuthors()
+  {
+    return cache.values().stream().map(CloudExpansion::getAuthor).collect(Collectors.toSet());
+  }
 
 
-		if (!allowUnverified)
-		{
-			future = future.thenApplyAsync((values) -> {
-				values.values().removeIf(expansion -> !expansion.isVerified());
-				return values;
-			});
-		}
+  public int getCloudExpansionAuthorCount()
+  {
+    return getCloudExpansionAuthors().size();
+  }
+
+  public int getCloudUpdateCount()
+  {
+    return ((int) plugin.getLocalExpansionManager()
+              .getExpansions()
+              .stream()
+              .filter(expansion -> findCloudExpansionByName(expansion.getName()).map(CloudExpansion::shouldUpdate).orElse(false))
+              .count());
+  }
 
 
-		future = future.thenApplyAsync((values) -> {
-
-			values.forEach((name, expansion) -> {
-				expansion.setName(name);
-
-				final Optional<PlaceholderExpansion> local = plugin.getLocalExpansionManager().findExpansionByName(name);
-				if (local.isPresent() && local.get().isRegistered())
-				{
-					expansion.setHasExpansion(true);
-					expansion.setShouldUpdate(!local.get().getVersion().equals(expansion.getLatestVersion()));
-				}
-			});
-
-			return values;
-		});
-
-		future.whenComplete((expansions, exception) -> {
-
-			if (exception != null)
-			{
-				plugin.getLogger().log(Level.WARNING, "failed to download expansion information", exception);
-				return;
-			}
-
-			for (final CloudExpansion expansion : expansions.values())
-			{
-				this.cache.put(toIndexName(expansion), expansion);
-			}
-		});
-	}
+  @NotNull
+  public Optional<CloudExpansion> findCloudExpansionByName(@NotNull final String name)
+  {
+    return Optional.ofNullable(cache.get(toIndexName(name)));
+  }
 
 
-	public boolean isDownloading(@NotNull final CloudExpansion expansion)
-	{
-		return await.containsKey(toIndexName(expansion));
-	}
+  public void clean()
+  {
+    cache.clear();
+
+    await.values().forEach(future -> future.cancel(true));
+    await.clear();
+  }
+
+  public void fetch(final boolean allowUnverified)
+  {
+    plugin.getLogger().info("Fetching available expansion information...");
+
+    CompletableFuture<Map<String, CloudExpansion>> future = CompletableFuture.supplyAsync(() -> {
+      final Map<String, CloudExpansion> values = new HashMap<>();
+
+      try
+      {
+        //noinspection UnstableApiUsage
+        final String json = Resources.toString(new URL(API_URL), StandardCharsets.UTF_8);
+        values.putAll(GSON.fromJson(json, TYPE));
+      }
+      catch (final IOException ex)
+      {
+        throw new CompletionException(ex);
+      }
+
+      values.values().removeIf(value -> value.getLatestVersion() == null || value.getVersion(value.getLatestVersion()) == null);
+
+      return values;
+    });
 
 
-	@NotNull
-	public CompletableFuture<File> downloadExpansion(@NotNull final CloudExpansion expansion, @NotNull final CloudExpansion.Version version)
-	{
-		final CompletableFuture<File> previous = await.get(toIndexName(expansion));
-		if (previous != null)
-		{
-			return previous;
-		}
-
-		final File file = new File(plugin.getLocalExpansionManager().getExpansionsFolder(), "Expansion-" + toIndexName(expansion) + ".jar");
-
-		final CompletableFuture<File> download = CompletableFuture.supplyAsync(() -> {
-			try (final ReadableByteChannel source = Channels.newChannel(new URL(version.getUrl()).openStream()); final FileOutputStream target = new FileOutputStream(file))
-			{
-				target.getChannel().transferFrom(source, 0, Long.MAX_VALUE);
-			}
-			catch (final IOException ex)
-			{
-				throw new CompletionException(ex);
-			}
-			return file;
-		});
-
-		download.whenCompleteAsync((value, exception) -> {
-			await.remove(toIndexName(expansion));
-
-			if (exception != null)
-			{
-				plugin.getLogger().log(Level.SEVERE, "failed to download " + expansion.getName() + ":" + version.getVersion(), exception);
-			}
-		});
-
-		await.put(toIndexName(expansion), download);
-
-		return download;
-	}
+    if (!allowUnverified)
+    {
+      future = future.thenApplyAsync((values) -> {
+        values.values().removeIf(expansion -> !expansion.isVerified());
+        return values;
+      });
+    }
 
 
-	@NotNull
-	private static String toIndexName(@NotNull final String name)
-	{
-		return name.toLowerCase().replace(' ', '_');
-	}
+    future = future.thenApplyAsync((values) -> {
 
-	@NotNull
-	private static String toIndexName(@NotNull final CloudExpansion expansion)
-	{
-		return toIndexName(expansion.getName());
-	}
+      values.forEach((name, expansion) -> {
+        expansion.setName(name);
+
+        final Optional<PlaceholderExpansion> local = plugin.getLocalExpansionManager().findExpansionByName(name);
+        if (local.isPresent() && local.get().isRegistered())
+        {
+          expansion.setHasExpansion(true);
+          expansion.setShouldUpdate(!local.get().getVersion().equals(expansion.getLatestVersion()));
+        }
+      });
+
+      return values;
+    });
+
+    future.whenComplete((expansions, exception) -> {
+
+      if (exception != null)
+      {
+        plugin.getLogger().log(Level.WARNING, "failed to download expansion information", exception);
+        return;
+      }
+
+      for (final CloudExpansion expansion : expansions.values())
+      {
+        this.cache.put(toIndexName(expansion), expansion);
+      }
+    });
+  }
+
+
+  public boolean isDownloading(@NotNull final CloudExpansion expansion)
+  {
+    return await.containsKey(toIndexName(expansion));
+  }
+
+
+  @NotNull
+  public CompletableFuture<File> downloadExpansion(@NotNull final CloudExpansion expansion, @NotNull final CloudExpansion.Version version)
+  {
+    final CompletableFuture<File> previous = await.get(toIndexName(expansion));
+    if (previous != null)
+    {
+      return previous;
+    }
+
+    final File file = new File(plugin.getLocalExpansionManager().getExpansionsFolder(), "Expansion-" + toIndexName(expansion) + ".jar");
+
+    final CompletableFuture<File> download = CompletableFuture.supplyAsync(() -> {
+      try (final ReadableByteChannel source = Channels.newChannel(new URL(version.getUrl()).openStream()); final FileOutputStream target = new FileOutputStream(file))
+      {
+        target.getChannel().transferFrom(source, 0, Long.MAX_VALUE);
+      }
+      catch (final IOException ex)
+      {
+        throw new CompletionException(ex);
+      }
+      return file;
+    });
+
+    download.whenCompleteAsync((value, exception) -> {
+      await.remove(toIndexName(expansion));
+
+      if (exception != null)
+      {
+        plugin.getLogger().log(Level.SEVERE, "failed to download " + expansion.getName() + ":" + version.getVersion(), exception);
+      }
+    });
+
+    await.put(toIndexName(expansion), download);
+
+    return download;
+  }
+
+
+  @NotNull
+  private static String toIndexName(@NotNull final String name)
+  {
+    return name.toLowerCase().replace(' ', '_');
+  }
+
+  @NotNull
+  private static String toIndexName(@NotNull final CloudExpansion expansion)
+  {
+    return toIndexName(expansion.getName());
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -58,367 +58,367 @@ import java.util.logging.Level;
 public final class LocalExpansionManager implements Listener
 {
 
-	@NotNull
-	private static final String EXPANSIONS_FOLDER_NAME = "expansions";
-
-
-	@NotNull
-	private final File                 folder;
-	@NotNull
-	private final PlaceholderAPIPlugin plugin;
-
-	@NotNull
-	private final Map<String, PlaceholderExpansion> expansions = new HashMap<>();
-
-
-	public LocalExpansionManager(@NotNull final PlaceholderAPIPlugin plugin)
-	{
-		this.plugin = plugin;
-		this.folder = new File(plugin.getDataFolder(), EXPANSIONS_FOLDER_NAME);
-
-		if (!this.folder.exists() && !folder.mkdirs())
-		{
-			plugin.getLogger().log(Level.WARNING, "failed to create expansions folder!");
-		}
-	}
-
-	public void load(@NotNull final CommandSender sender)
-	{
-		registerAll(sender);
-	}
-
-	public void kill()
-	{
-		unregisterAll();
-	}
-
-
-	@NotNull
-	public File getExpansionsFolder()
-	{
-		return folder;
-	}
-
-	public int getExpansionsCount()
-	{
-		return expansions.size();
-	}
-
-
-	@NotNull
-	@Unmodifiable
-	public Collection<String> getIdentifiers()
-	{
-		return ImmutableSet.copyOf(expansions.keySet());
-	}
-
-	@NotNull
-	@Unmodifiable
-	public Collection<PlaceholderExpansion> getExpansions()
-	{
-		return ImmutableSet.copyOf(expansions.values());
-	}
-
-
-	@Nullable
-	public PlaceholderExpansion getExpansion(@NotNull final String identifier)
-	{
-		return expansions.get(identifier.toLowerCase());
-	}
-
-
-	@NotNull
-	public Optional<PlaceholderExpansion> findExpansionByName(@NotNull final String name)
-	{
-		return expansions.values().stream().filter(expansion -> name.equalsIgnoreCase(expansion.getName())).findFirst();
-	}
-
-	@NotNull
-	public Optional<PlaceholderExpansion> findExpansionByIdentifier(@NotNull final String identifier)
-	{
-		return Optional.ofNullable(getExpansion(identifier));
-	}
-
-
-	public Optional<PlaceholderExpansion> register(@NotNull final Class<? extends PlaceholderExpansion> clazz)
-	{
-		try
-		{
-			final PlaceholderExpansion expansion = createExpansionInstance(clazz);
-			if (expansion == null || !expansion.register())
-			{
-				return Optional.empty();
-			}
-
-			return Optional.of(expansion);
-		}
-		catch (final LinkageError ex)
-		{
-			plugin.getLogger().severe("expansion class " + clazz.getSimpleName() + " is outdated: \n" +
-									  "Failed to load due to a [" + ex.getClass().getSimpleName() + "], attempted to use " + ex.getMessage());
-		}
-
-		return Optional.empty();
-	}
-
-	/**
-	 * Do not call this method yourself, use {@link PlaceholderExpansion#register()}
-	 */
-	@ApiStatus.Internal
-	public boolean register(@NotNull final PlaceholderExpansion expansion)
-	{
-		final String identifier = expansion.getIdentifier();
-
-		if (expansion instanceof Configurable)
-		{
-			Map<String, Object> defaults = ((Configurable) expansion).getDefaults();
-			String              pre      = "expansions." + expansion.getIdentifier() + ".";
-			FileConfiguration   cfg      = plugin.getConfig();
-			boolean             save     = false;
-
-			if (defaults != null)
-			{
-				for (Map.Entry<String, Object> entries : defaults.entrySet())
-				{
-					if (entries.getKey() == null || entries.getKey().isEmpty())
-					{
-						continue;
-					}
-
-					if (entries.getValue() == null)
-					{
-						if (cfg.contains(pre + entries.getKey()))
-						{
-							save = true;
-							cfg.set(pre + entries.getKey(), null);
-						}
-					}
-					else
-					{
-						if (!cfg.contains(pre + entries.getKey()))
-						{
-							save = true;
-							cfg.set(pre + entries.getKey(), entries.getValue());
-						}
-					}
-				}
-			}
-
-			if (save)
-			{
-				plugin.saveConfig();
-				plugin.reloadConfig();
-			}
-		}
-
-		if (expansion instanceof VersionSpecific)
-		{
-			VersionSpecific nms = (VersionSpecific) expansion;
-			if (!nms.isCompatibleWith(PlaceholderAPIPlugin.getServerVersion()))
-			{
-				plugin.getLogger().info("Your server version is not compatible with expansion: " + expansion.getIdentifier() + " version: " + expansion.getVersion());
-				return false;
-			}
-		}
-
-		final PlaceholderExpansion removed = expansions.get(expansion.getIdentifier());
-		if (removed != null && !removed.unregister())
-		{
-			return false;
-		}
-
-		final ExpansionRegisterEvent event = new ExpansionRegisterEvent(expansion);
-		Bukkit.getPluginManager().callEvent(event);
-
-		if (event.isCancelled())
-		{
-			return false;
-		}
-
-		expansions.put(expansion.getIdentifier(), expansion);
-
-		if (expansion instanceof Listener)
-		{
-			Bukkit.getPluginManager().registerEvents(((Listener) expansion), plugin);
-		}
-
-		plugin.getLogger().info("Successfully registered expansion: " + expansion.getIdentifier());
-
-		if (expansion instanceof Taskable)
-		{
-			((Taskable) expansion).start();
-		}
-
-		if (plugin.getPlaceholderAPIConfig().isCloudEnabled())
-		{
-			final Optional<CloudExpansion> cloudExpansion = plugin.getCloudExpansionManager().findCloudExpansionByName(identifier);
-			if (cloudExpansion.isPresent())
-			{
-				cloudExpansion.get().setHasExpansion(true);
-				cloudExpansion.get().setShouldUpdate(!cloudExpansion.get().getLatestVersion().equals(expansion.getVersion()));
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Do not call this method yourself, use {@link PlaceholderExpansion#unregister()}
-	 */
-	@ApiStatus.Internal
-	public boolean unregister(@NotNull final PlaceholderExpansion expansion)
-	{
-		if (expansions.remove(expansion.getIdentifier()) == null)
-		{
-			return false;
-		}
-
-
-		Bukkit.getPluginManager().callEvent(new ExpansionUnregisterEvent(expansion));
-
-
-		if (expansion instanceof Listener)
-		{
-			HandlerList.unregisterAll((Listener) expansion);
-		}
-
-		if (expansion instanceof Taskable)
-		{
-			((Taskable) expansion).stop();
-		}
-
-		if (expansion instanceof Cacheable)
-		{
-			((Cacheable) expansion).clear();
-		}
-
-		if (plugin.getPlaceholderAPIConfig().isCloudEnabled())
-		{
-			plugin.getCloudExpansionManager().findCloudExpansionByName(expansion.getName()).ifPresent(cloud -> {
-				cloud.setHasExpansion(false);
-				cloud.setShouldUpdate(false);
-			});
-		}
-
-		return true;
-	}
-
-
-	private void registerAll(@NotNull final CommandSender sender)
-	{
-		plugin.getLogger().info("Placeholder expansion registration initializing...");
-
-		Futures.onMainThread(plugin, findExpansionsOnDisk(), (classes, exception) -> {
-			if (exception != null)
-			{
-				plugin.getLogger().log(Level.SEVERE, "failed to load class files of expansions", exception);
-				return;
-			}
-
-			final long registered = classes.stream().map(this::register).filter(Optional::isPresent).count();
-
-			Msg.msg(sender,
-					registered == 0 ? "&6No expansions were registered!" : registered + "&a placeholder hooks successfully registered!");
-		});
-	}
-
-	private void unregisterAll()
-	{
-		for (final PlaceholderExpansion expansion : Sets.newHashSet(expansions.values()))
-		{
-			if (expansion.persist())
-			{
-				continue;
-			}
-
-			expansion.unregister();
-		}
-	}
-
-
-	@NotNull
-	public CompletableFuture<@NotNull List<@NotNull Class<? extends PlaceholderExpansion>>> findExpansionsOnDisk()
-	{
-		return Arrays.stream(folder.listFiles((dir, name) -> name.endsWith(".jar")))
-					 .map(this::findExpansionInFile)
-					 .collect(Futures.collector());
-	}
-
-	@NotNull
-	public CompletableFuture<@Nullable Class<? extends PlaceholderExpansion>> findExpansionInFile(@NotNull final File file)
-	{
-		return CompletableFuture.supplyAsync(() -> {
-			try
-			{
-				return FileUtil.findClass(file, PlaceholderExpansion.class);
-			}
-			catch (final VerifyError ex)
-			{
-				plugin.getLogger().severe("expansion file " + file.getName() + " is outdated: \n" +
-										  "Failed to load due to a [" + ex.getClass().getSimpleName() + "], attempted to use" + ex.getMessage().substring(ex.getMessage().lastIndexOf(' ')));
-				return null;
-			}
-			catch (final Exception ex)
-			{
-				throw new CompletionException(ex);
-			}
-		});
-	}
-
-
-	@Nullable
-	public PlaceholderExpansion createExpansionInstance(@NotNull final Class<? extends PlaceholderExpansion> clazz) throws LinkageError
-	{
-		try
-		{
-			return clazz.getDeclaredConstructor().newInstance();
-		}
-		catch (final Exception ex)
-		{
-			if (ex.getCause() instanceof LinkageError)
-			{
-				throw ((LinkageError) ex.getCause());
-			}
-
-			plugin.getLogger().log(Level.SEVERE, "Failed to load placeholder expansion from class: " + clazz.getName(), ex);
-			return null;
-		}
-	}
-
-
-	@EventHandler
-	public void onQuit(@NotNull final PlayerQuitEvent event)
-	{
-		for (final PlaceholderExpansion expansion : getExpansions())
-		{
-			if (!(expansion instanceof Cleanable))
-			{
-				continue;
-			}
-
-			((Cleanable) expansion).cleanup(event.getPlayer());
-		}
-	}
-
-	@EventHandler(priority = EventPriority.HIGH)
-	public void onPluginDisable(@NotNull final PluginDisableEvent event)
-	{
-		final String name = event.getPlugin().getName();
-		if (name.equals(plugin.getName()))
-		{
-			return;
-		}
-
-		for (final PlaceholderExpansion expansion : getExpansions())
-		{
-			if (!name.equalsIgnoreCase(expansion.getRequiredPlugin()))
-			{
-				continue;
-			}
-
-			expansion.unregister();
-			plugin.getLogger().info("Unregistered placeholder expansion: " + expansion.getName());
-		}
-	}
+  @NotNull
+  private static final String EXPANSIONS_FOLDER_NAME = "expansions";
+
+
+  @NotNull
+  private final File                 folder;
+  @NotNull
+  private final PlaceholderAPIPlugin plugin;
+
+  @NotNull
+  private final Map<String, PlaceholderExpansion> expansions = new HashMap<>();
+
+
+  public LocalExpansionManager(@NotNull final PlaceholderAPIPlugin plugin)
+  {
+    this.plugin = plugin;
+    this.folder = new File(plugin.getDataFolder(), EXPANSIONS_FOLDER_NAME);
+
+    if (!this.folder.exists() && !folder.mkdirs())
+    {
+      plugin.getLogger().log(Level.WARNING, "failed to create expansions folder!");
+    }
+  }
+
+  public void load(@NotNull final CommandSender sender)
+  {
+    registerAll(sender);
+  }
+
+  public void kill()
+  {
+    unregisterAll();
+  }
+
+
+  @NotNull
+  public File getExpansionsFolder()
+  {
+    return folder;
+  }
+
+  public int getExpansionsCount()
+  {
+    return expansions.size();
+  }
+
+
+  @NotNull
+  @Unmodifiable
+  public Collection<String> getIdentifiers()
+  {
+    return ImmutableSet.copyOf(expansions.keySet());
+  }
+
+  @NotNull
+  @Unmodifiable
+  public Collection<PlaceholderExpansion> getExpansions()
+  {
+    return ImmutableSet.copyOf(expansions.values());
+  }
+
+
+  @Nullable
+  public PlaceholderExpansion getExpansion(@NotNull final String identifier)
+  {
+    return expansions.get(identifier.toLowerCase());
+  }
+
+
+  @NotNull
+  public Optional<PlaceholderExpansion> findExpansionByName(@NotNull final String name)
+  {
+    return expansions.values().stream().filter(expansion -> name.equalsIgnoreCase(expansion.getName())).findFirst();
+  }
+
+  @NotNull
+  public Optional<PlaceholderExpansion> findExpansionByIdentifier(@NotNull final String identifier)
+  {
+    return Optional.ofNullable(getExpansion(identifier));
+  }
+
+
+  public Optional<PlaceholderExpansion> register(@NotNull final Class<? extends PlaceholderExpansion> clazz)
+  {
+    try
+    {
+      final PlaceholderExpansion expansion = createExpansionInstance(clazz);
+      if (expansion == null || !expansion.register())
+      {
+        return Optional.empty();
+      }
+
+      return Optional.of(expansion);
+    }
+    catch (final LinkageError ex)
+    {
+      plugin.getLogger().severe("expansion class " + clazz.getSimpleName() + " is outdated: \n" +
+                    "Failed to load due to a [" + ex.getClass().getSimpleName() + "], attempted to use " + ex.getMessage());
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Do not call this method yourself, use {@link PlaceholderExpansion#register()}
+   */
+  @ApiStatus.Internal
+  public boolean register(@NotNull final PlaceholderExpansion expansion)
+  {
+    final String identifier = expansion.getIdentifier();
+
+    if (expansion instanceof Configurable)
+    {
+      Map<String, Object> defaults = ((Configurable) expansion).getDefaults();
+      String              pre      = "expansions." + expansion.getIdentifier() + ".";
+      FileConfiguration   cfg      = plugin.getConfig();
+      boolean             save     = false;
+
+      if (defaults != null)
+      {
+        for (Map.Entry<String, Object> entries : defaults.entrySet())
+        {
+          if (entries.getKey() == null || entries.getKey().isEmpty())
+          {
+            continue;
+          }
+
+          if (entries.getValue() == null)
+          {
+            if (cfg.contains(pre + entries.getKey()))
+            {
+              save = true;
+              cfg.set(pre + entries.getKey(), null);
+            }
+          }
+          else
+          {
+            if (!cfg.contains(pre + entries.getKey()))
+            {
+              save = true;
+              cfg.set(pre + entries.getKey(), entries.getValue());
+            }
+          }
+        }
+      }
+
+      if (save)
+      {
+        plugin.saveConfig();
+        plugin.reloadConfig();
+      }
+    }
+
+    if (expansion instanceof VersionSpecific)
+    {
+      VersionSpecific nms = (VersionSpecific) expansion;
+      if (!nms.isCompatibleWith(PlaceholderAPIPlugin.getServerVersion()))
+      {
+        plugin.getLogger().info("Your server version is not compatible with expansion: " + expansion.getIdentifier() + " version: " + expansion.getVersion());
+        return false;
+      }
+    }
+
+    final PlaceholderExpansion removed = expansions.get(expansion.getIdentifier());
+    if (removed != null && !removed.unregister())
+    {
+      return false;
+    }
+
+    final ExpansionRegisterEvent event = new ExpansionRegisterEvent(expansion);
+    Bukkit.getPluginManager().callEvent(event);
+
+    if (event.isCancelled())
+    {
+      return false;
+    }
+
+    expansions.put(expansion.getIdentifier(), expansion);
+
+    if (expansion instanceof Listener)
+    {
+      Bukkit.getPluginManager().registerEvents(((Listener) expansion), plugin);
+    }
+
+    plugin.getLogger().info("Successfully registered expansion: " + expansion.getIdentifier());
+
+    if (expansion instanceof Taskable)
+    {
+      ((Taskable) expansion).start();
+    }
+
+    if (plugin.getPlaceholderAPIConfig().isCloudEnabled())
+    {
+      final Optional<CloudExpansion> cloudExpansion = plugin.getCloudExpansionManager().findCloudExpansionByName(identifier);
+      if (cloudExpansion.isPresent())
+      {
+        cloudExpansion.get().setHasExpansion(true);
+        cloudExpansion.get().setShouldUpdate(!cloudExpansion.get().getLatestVersion().equals(expansion.getVersion()));
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Do not call this method yourself, use {@link PlaceholderExpansion#unregister()}
+   */
+  @ApiStatus.Internal
+  public boolean unregister(@NotNull final PlaceholderExpansion expansion)
+  {
+    if (expansions.remove(expansion.getIdentifier()) == null)
+    {
+      return false;
+    }
+
+
+    Bukkit.getPluginManager().callEvent(new ExpansionUnregisterEvent(expansion));
+
+
+    if (expansion instanceof Listener)
+    {
+      HandlerList.unregisterAll((Listener) expansion);
+    }
+
+    if (expansion instanceof Taskable)
+    {
+      ((Taskable) expansion).stop();
+    }
+
+    if (expansion instanceof Cacheable)
+    {
+      ((Cacheable) expansion).clear();
+    }
+
+    if (plugin.getPlaceholderAPIConfig().isCloudEnabled())
+    {
+      plugin.getCloudExpansionManager().findCloudExpansionByName(expansion.getName()).ifPresent(cloud -> {
+        cloud.setHasExpansion(false);
+        cloud.setShouldUpdate(false);
+      });
+    }
+
+    return true;
+  }
+
+
+  private void registerAll(@NotNull final CommandSender sender)
+  {
+    plugin.getLogger().info("Placeholder expansion registration initializing...");
+
+    Futures.onMainThread(plugin, findExpansionsOnDisk(), (classes, exception) -> {
+      if (exception != null)
+      {
+        plugin.getLogger().log(Level.SEVERE, "failed to load class files of expansions", exception);
+        return;
+      }
+
+      final long registered = classes.stream().map(this::register).filter(Optional::isPresent).count();
+
+      Msg.msg(sender,
+          registered == 0 ? "&6No expansions were registered!" : registered + "&a placeholder hooks successfully registered!");
+    });
+  }
+
+  private void unregisterAll()
+  {
+    for (final PlaceholderExpansion expansion : Sets.newHashSet(expansions.values()))
+    {
+      if (expansion.persist())
+      {
+        continue;
+      }
+
+      expansion.unregister();
+    }
+  }
+
+
+  @NotNull
+  public CompletableFuture<@NotNull List<@NotNull Class<? extends PlaceholderExpansion>>> findExpansionsOnDisk()
+  {
+    return Arrays.stream(folder.listFiles((dir, name) -> name.endsWith(".jar")))
+           .map(this::findExpansionInFile)
+           .collect(Futures.collector());
+  }
+
+  @NotNull
+  public CompletableFuture<@Nullable Class<? extends PlaceholderExpansion>> findExpansionInFile(@NotNull final File file)
+  {
+    return CompletableFuture.supplyAsync(() -> {
+      try
+      {
+        return FileUtil.findClass(file, PlaceholderExpansion.class);
+      }
+      catch (final VerifyError ex)
+      {
+        plugin.getLogger().severe("expansion file " + file.getName() + " is outdated: \n" +
+                      "Failed to load due to a [" + ex.getClass().getSimpleName() + "], attempted to use" + ex.getMessage().substring(ex.getMessage().lastIndexOf(' ')));
+        return null;
+      }
+      catch (final Exception ex)
+      {
+        throw new CompletionException(ex);
+      }
+    });
+  }
+
+
+  @Nullable
+  public PlaceholderExpansion createExpansionInstance(@NotNull final Class<? extends PlaceholderExpansion> clazz) throws LinkageError
+  {
+    try
+    {
+      return clazz.getDeclaredConstructor().newInstance();
+    }
+    catch (final Exception ex)
+    {
+      if (ex.getCause() instanceof LinkageError)
+      {
+        throw ((LinkageError) ex.getCause());
+      }
+
+      plugin.getLogger().log(Level.SEVERE, "Failed to load placeholder expansion from class: " + clazz.getName(), ex);
+      return null;
+    }
+  }
+
+
+  @EventHandler
+  public void onQuit(@NotNull final PlayerQuitEvent event)
+  {
+    for (final PlaceholderExpansion expansion : getExpansions())
+    {
+      if (!(expansion instanceof Cleanable))
+      {
+        continue;
+      }
+
+      ((Cleanable) expansion).cleanup(event.getPlayer());
+    }
+  }
+
+  @EventHandler(priority = EventPriority.HIGH)
+  public void onPluginDisable(@NotNull final PluginDisableEvent event)
+  {
+    final String name = event.getPlugin().getName();
+    if (name.equals(plugin.getName()))
+    {
+      return;
+    }
+
+    for (final PlaceholderExpansion expansion : getExpansions())
+    {
+      if (!name.equalsIgnoreCase(expansion.getRequiredPlugin()))
+      {
+        continue;
+      }
+
+      expansion.unregister();
+      plugin.getLogger().info("Unregistered placeholder expansion: " + expansion.getName());
+    }
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/listeners/ServerLoadEventListener.java
+++ b/src/main/java/me/clip/placeholderapi/listeners/ServerLoadEventListener.java
@@ -32,30 +32,30 @@ public final class ServerLoadEventListener implements Listener
 {
 
     @NotNull
-	private final PlaceholderAPIPlugin plugin;
+  private final PlaceholderAPIPlugin plugin;
 
-	public ServerLoadEventListener(@NotNull final PlaceholderAPIPlugin plugin)
-	{
+  public ServerLoadEventListener(@NotNull final PlaceholderAPIPlugin plugin)
+  {
         this.plugin = plugin;
 
-		Bukkit.getPluginManager().registerEvents(this, plugin);
-	}
+    Bukkit.getPluginManager().registerEvents(this, plugin);
+  }
 
-	/**
-	 * This method will be called when the server is first loaded
-	 * <p>
-	 * The goal of the method is to register all the expansions as soon as possible
-	 * especially before players can join
-	 * <p>
-	 * This will ensure no issues with expansions and hooks.
-	 *
-	 * @param event the server load event
-	 */
-	@EventHandler
-	public void onServerLoad(@NotNull final ServerLoadEvent event)
-	{
+  /**
+   * This method will be called when the server is first loaded
+   * <p>
+   * The goal of the method is to register all the expansions as soon as possible
+   * especially before players can join
+   * <p>
+   * This will ensure no issues with expansions and hooks.
+   *
+   * @param event the server load event
+   */
+  @EventHandler
+  public void onServerLoad(@NotNull final ServerLoadEvent event)
+  {
         HandlerList.unregisterAll(this);
         plugin.getLocalExpansionManager().load(Bukkit.getConsoleSender());
-	}
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
+++ b/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
@@ -31,170 +31,170 @@ import java.util.function.Function;
 public final class CharsReplacer implements Replacer
 {
 
-	@NotNull
-	private final Closure closure;
+  @NotNull
+  private final Closure closure;
 
-	public CharsReplacer(@NotNull final Closure closure)
-	{
-		this.closure = closure;
-	}
+  public CharsReplacer(@NotNull final Closure closure)
+  {
+    this.closure = closure;
+  }
 
 
-	@NotNull
-	@Override
-	public String apply(@NotNull final String text, @Nullable final OfflinePlayer player, @NotNull final Function<String, @Nullable PlaceholderExpansion> lookup)
-	{
-		final char[]        chars   = text.toCharArray();
-		final StringBuilder builder = new StringBuilder(text.length());
+  @NotNull
+  @Override
+  public String apply(@NotNull final String text, @Nullable final OfflinePlayer player, @NotNull final Function<String, @Nullable PlaceholderExpansion> lookup)
+  {
+    final char[]        chars   = text.toCharArray();
+    final StringBuilder builder = new StringBuilder(text.length());
 
-		final StringBuilder identifier = new StringBuilder();
-		final StringBuilder parameters = new StringBuilder();
+    final StringBuilder identifier = new StringBuilder();
+    final StringBuilder parameters = new StringBuilder();
 
-		for (int i = 0; i < chars.length; i++)
-		{
-			final char l = chars[i];
+    for (int i = 0; i < chars.length; i++)
+    {
+      final char l = chars[i];
 
-			if (l == '&' && ++i < chars.length)
-			{
-				final char c = Character.toLowerCase(chars[i]);
+      if (l == '&' && ++i < chars.length)
+      {
+        final char c = Character.toLowerCase(chars[i]);
 
-				if (c != '0' && c != '1' && c != '2' && c != '3' && c != '4' && c != '5' && c != '6' && c != '7' && c != '8' && c != '9' && c != 'a' && c != 'b' && c != 'c' && c != 'd' && c != 'e' && c != 'f' && c != 'k' && c != 'l' && c != 'm' && c != 'o' && c != 'r' && c != 'x')
-				{
-					builder.append(l).append(chars[i]);
-				}
-				else
-				{
-					builder.append(ChatColor.COLOR_CHAR);
+        if (c != '0' && c != '1' && c != '2' && c != '3' && c != '4' && c != '5' && c != '6' && c != '7' && c != '8' && c != '9' && c != 'a' && c != 'b' && c != 'c' && c != 'd' && c != 'e' && c != 'f' && c != 'k' && c != 'l' && c != 'm' && c != 'o' && c != 'r' && c != 'x')
+        {
+          builder.append(l).append(chars[i]);
+        }
+        else
+        {
+          builder.append(ChatColor.COLOR_CHAR);
 
-					if (c != 'x')
-					{
-						builder.append(chars[i]);
-						continue;
-					}
+          if (c != 'x')
+          {
+            builder.append(chars[i]);
+            continue;
+          }
 
-					if ((i > 1 && chars[i - 2] == '\\') /*allow escaping &x*/)
-					{
-						builder.setLength(builder.length() - 2);
-						builder.append('&').append(chars[i]);
-						continue;
-					}
+          if ((i > 1 && chars[i - 2] == '\\') /*allow escaping &x*/)
+          {
+            builder.setLength(builder.length() - 2);
+            builder.append('&').append(chars[i]);
+            continue;
+          }
 
-					builder.append(c);
+          builder.append(c);
 
-					int j = 0;
-					while (++j <= 6)
-					{
-						if (i + j >= chars.length)
-						{
-							break;
-						}
+          int j = 0;
+          while (++j <= 6)
+          {
+            if (i + j >= chars.length)
+            {
+              break;
+            }
 
-						final char x = chars[i + j];
-						builder.append(ChatColor.COLOR_CHAR).append(x);
-					}
+            final char x = chars[i + j];
+            builder.append(ChatColor.COLOR_CHAR).append(x);
+          }
 
-					if (j == 7)
-					{
-						i += 6;
-					}
-					else
-					{
-						builder.setLength(builder.length() - (j * 2)); // undo &x parsing
-					}
-				}
-				continue;
-			}
+          if (j == 7)
+          {
+            i += 6;
+          }
+          else
+          {
+            builder.setLength(builder.length() - (j * 2)); // undo &x parsing
+          }
+        }
+        continue;
+      }
 
-			if (l != closure.head || i + 1 >= chars.length)
-			{
-				builder.append(l);
-				continue;
-			}
+      if (l != closure.head || i + 1 >= chars.length)
+      {
+        builder.append(l);
+        continue;
+      }
 
-			boolean identified = false;
-			boolean oopsitsbad = true;
+      boolean identified = false;
+      boolean oopsitsbad = true;
 
-			while (++i < chars.length)
-			{
-				final char p = chars[i];
+      while (++i < chars.length)
+      {
+        final char p = chars[i];
 
-				if (p == ' ' && !identified)
-				{
-					break;
-				}
-				if (p == closure.tail)
-				{
-					oopsitsbad = false;
-					break;
-				}
+        if (p == ' ' && !identified)
+        {
+          break;
+        }
+        if (p == closure.tail)
+        {
+          oopsitsbad = false;
+          break;
+        }
 
-				if (p == '_' && !identified)
-				{
-					identified = true;
-					continue;
-				}
+        if (p == '_' && !identified)
+        {
+          identified = true;
+          continue;
+        }
 
-				if (identified)
-				{
-					parameters.append(p);
-				}
-				else
-				{
-					identifier.append(p);
-				}
-			}
+        if (identified)
+        {
+          parameters.append(p);
+        }
+        else
+        {
+          identifier.append(p);
+        }
+      }
 
-			final String identifierString = identifier.toString();
-			final String parametersString = parameters.toString();
+      final String identifierString = identifier.toString();
+      final String parametersString = parameters.toString();
 
-			identifier.setLength(0);
-			parameters.setLength(0);
+      identifier.setLength(0);
+      parameters.setLength(0);
 
-			if (oopsitsbad)
-			{
-				builder.append(closure.head).append(identifierString);
+      if (oopsitsbad)
+      {
+        builder.append(closure.head).append(identifierString);
 
-				if (identified)
-				{
-					builder.append('_').append(parametersString);
-				}
+        if (identified)
+        {
+          builder.append('_').append(parametersString);
+        }
 
-				builder.append(' ');
-				continue;
-			}
+        builder.append(' ');
+        continue;
+      }
 
-			final PlaceholderExpansion placeholder = lookup.apply(identifierString);
-			if (placeholder == null)
-			{
-				builder.append(closure.head).append(identifierString);
+      final PlaceholderExpansion placeholder = lookup.apply(identifierString);
+      if (placeholder == null)
+      {
+        builder.append(closure.head).append(identifierString);
 
-				if (identified)
-				{
-					builder.append('_');
-				}
+        if (identified)
+        {
+          builder.append('_');
+        }
 
-				builder.append(parametersString).append(closure.tail);
-				continue;
-			}
+        builder.append(parametersString).append(closure.tail);
+        continue;
+      }
 
-			final String replacement = placeholder.onRequest(player, parametersString);
-			if (replacement == null)
-			{
-				builder.append(closure.head).append(identifierString);
+      final String replacement = placeholder.onRequest(player, parametersString);
+      if (replacement == null)
+      {
+        builder.append(closure.head).append(identifierString);
 
-				if (identified)
-				{
-					builder.append('_');
-				}
+        if (identified)
+        {
+          builder.append('_');
+        }
 
-				builder.append(parametersString).append(closure.tail);
-				continue;
-			}
+        builder.append(parametersString).append(closure.tail);
+        continue;
+      }
 
-			builder.append(ChatColor.translateAlternateColorCodes('&', replacement));
-		}
+      builder.append(ChatColor.translateAlternateColorCodes('&', replacement));
+    }
 
-		return builder.toString();
-	}
+    return builder.toString();
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/replacer/RegexReplacer.java
+++ b/src/main/java/me/clip/placeholderapi/replacer/RegexReplacer.java
@@ -33,44 +33,44 @@ import java.util.regex.Pattern;
 public final class RegexReplacer implements Replacer
 {
 
-	@NotNull
-	private final Pattern pattern;
+  @NotNull
+  private final Pattern pattern;
 
-	public RegexReplacer(@NotNull final Closure closure)
-	{
-		this.pattern = Pattern.compile(String.format("\\%s((?<identifier>[a-zA-Z0-9]+)_)(?<parameters>[^%s%s]+)\\%s", closure.head, closure.head, closure.tail, closure.tail));
-	}
+  public RegexReplacer(@NotNull final Closure closure)
+  {
+    this.pattern = Pattern.compile(String.format("\\%s((?<identifier>[a-zA-Z0-9]+)_)(?<parameters>[^%s%s]+)\\%s", closure.head, closure.head, closure.tail, closure.tail));
+  }
 
 
-	@NotNull
-	@Override
-	public String apply(@NotNull final String text, @Nullable final OfflinePlayer player, @NotNull final Function<String, @Nullable PlaceholderExpansion> lookup)
-	{
-		final Matcher matcher = pattern.matcher(text);
-		if (!matcher.find())
-		{
-			return text;
-		}
+  @NotNull
+  @Override
+  public String apply(@NotNull final String text, @Nullable final OfflinePlayer player, @NotNull final Function<String, @Nullable PlaceholderExpansion> lookup)
+  {
+    final Matcher matcher = pattern.matcher(text);
+    if (!matcher.find())
+    {
+      return text;
+    }
 
-		final StringBuffer builder = new StringBuffer();
+    final StringBuffer builder = new StringBuffer();
 
-		do
-		{
-			final String identifier = matcher.group("identifier");
-			final String parameters = matcher.group("parameters");
+    do
+    {
+      final String identifier = matcher.group("identifier");
+      final String parameters = matcher.group("parameters");
 
-			final PlaceholderExpansion expansion = lookup.apply(identifier);
-			if (expansion == null)
-			{
-				continue;
-			}
+      final PlaceholderExpansion expansion = lookup.apply(identifier);
+      if (expansion == null)
+      {
+        continue;
+      }
 
-			final String requested = expansion.onRequest(player, parameters);
-			matcher.appendReplacement(builder, requested != null ? requested : matcher.group(0));
-		}
-		while (matcher.find());
+      final String requested = expansion.onRequest(player, parameters);
+      matcher.appendReplacement(builder, requested != null ? requested : matcher.group(0));
+    }
+    while (matcher.find());
 
-		return ChatColor.translateAlternateColorCodes('&', matcher.appendTail(builder).toString());
-	}
+    return ChatColor.translateAlternateColorCodes('&', matcher.appendTail(builder).toString());
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/replacer/Replacer.java
+++ b/src/main/java/me/clip/placeholderapi/replacer/Replacer.java
@@ -30,23 +30,23 @@ import java.util.function.Function;
 public interface Replacer
 {
 
-	@NotNull
-	String apply(@NotNull final String text, @Nullable final OfflinePlayer player, @NotNull final Function<String, @Nullable PlaceholderExpansion> lookup);
+  @NotNull
+  String apply(@NotNull final String text, @Nullable final OfflinePlayer player, @NotNull final Function<String, @Nullable PlaceholderExpansion> lookup);
 
 
-	enum Closure
-	{
-		BRACKET('{', '}'),
-		PERCENT('%', '%');
+  enum Closure
+  {
+    BRACKET('{', '}'),
+    PERCENT('%', '%');
 
 
-		public final char head, tail;
+    public final char head, tail;
 
-		Closure(final char head, final char tail)
-		{
-			this.head = head;
-			this.tail = tail;
-		}
-	}
+    Closure(final char head, final char tail)
+    {
+      this.head = head;
+      this.tail = tail;
+    }
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/util/FileUtil.java
+++ b/src/main/java/me/clip/placeholderapi/util/FileUtil.java
@@ -35,50 +35,50 @@ import java.util.jar.JarInputStream;
 public class FileUtil
 {
 
-	@Nullable
-	public static <T> Class<? extends T> findClass(@NotNull final File file, @NotNull final Class<T> clazz) throws IOException, ClassNotFoundException
-	{
-		if (!file.exists())
-		{
-			return null;
-		}
+  @Nullable
+  public static <T> Class<? extends T> findClass(@NotNull final File file, @NotNull final Class<T> clazz) throws IOException, ClassNotFoundException
+  {
+    if (!file.exists())
+    {
+      return null;
+    }
 
-		final URL jar = file.toURI().toURL();
+    final URL jar = file.toURI().toURL();
 
-		final List<String>             matches = new ArrayList<>();
-		final List<Class<? extends T>> classes = new ArrayList<>();
+    final List<String>             matches = new ArrayList<>();
+    final List<Class<? extends T>> classes = new ArrayList<>();
 
 
-		try (final JarInputStream stream = new JarInputStream(jar.openStream()); final URLClassLoader loader = new URLClassLoader(new URL[]{jar}, clazz.getClassLoader()))
-		{
-			JarEntry entry;
-			while ((entry = stream.getNextJarEntry()) != null)
-			{
-				final String name = entry.getName();
-				if (name == null || name.isEmpty() || !name.endsWith(".class"))
-				{
-					continue;
-				}
+    try (final JarInputStream stream = new JarInputStream(jar.openStream()); final URLClassLoader loader = new URLClassLoader(new URL[]{jar}, clazz.getClassLoader()))
+    {
+      JarEntry entry;
+      while ((entry = stream.getNextJarEntry()) != null)
+      {
+        final String name = entry.getName();
+        if (name == null || name.isEmpty() || !name.endsWith(".class"))
+        {
+          continue;
+        }
 
-				matches.add(name.substring(0, name.lastIndexOf('.')).replace('/', '.'));
-			}
+        matches.add(name.substring(0, name.lastIndexOf('.')).replace('/', '.'));
+      }
 
-			for (final String match : matches)
-			{
-				try
-				{
-					final Class<?> loaded = loader.loadClass(match);
-					if (clazz.isAssignableFrom(loaded))
-					{
-						classes.add(loaded.asSubclass(clazz));
-					}
-				}
-				catch (final NoClassDefFoundError ignored)
-				{ }
-			}
-		}
+      for (final String match : matches)
+      {
+        try
+        {
+          final Class<?> loaded = loader.loadClass(match);
+          if (clazz.isAssignableFrom(loaded))
+          {
+            classes.add(loaded.asSubclass(clazz));
+          }
+        }
+        catch (final NoClassDefFoundError ignored)
+        { }
+      }
+    }
 
-		return classes.isEmpty() ? null : classes.get(0);
-	}
+    return classes.isEmpty() ? null : classes.get(0);
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/util/Format.java
+++ b/src/main/java/me/clip/placeholderapi/util/Format.java
@@ -38,41 +38,41 @@ import static java.util.stream.IntStream.range;
 public final class Format
 {
 
-	private Format()
-	{}
+  private Format()
+  {}
 
 
-	public enum Align
-	{
-		LEFT, RIGHT
-	}
+  public enum Align
+  {
+    LEFT, RIGHT
+  }
 
 
-	@NotNull
-	public static Optional<List<String>> tablify(@NotNull final Align align, @NotNull final List<List<String>> rows)
-	{
-		return findSpacing(rows)
-				.map(spacing -> buildFormat(align, spacing))
-				.map(format -> rows.stream()
-								   .map(row -> String.format(format, row.toArray()).substring(align == Align.RIGHT ? 2 : 0))
-								   .collect(toList()));
-	}
+  @NotNull
+  public static Optional<List<String>> tablify(@NotNull final Align align, @NotNull final List<List<String>> rows)
+  {
+    return findSpacing(rows)
+        .map(spacing -> buildFormat(align, spacing))
+        .map(format -> rows.stream()
+                   .map(row -> String.format(format, row.toArray()).substring(align == Align.RIGHT ? 2 : 0))
+                   .collect(toList()));
+  }
 
 
-	@NotNull
-	private static String buildFormat(@NotNull final Align align, @NotNull final int[] spacing)
-	{
-		return stream(spacing)
-				.mapToObj(space -> "%" + (align == Align.LEFT ? "-" : "") + (space + 2) + "s")
-				.collect(joining());
-	}
+  @NotNull
+  private static String buildFormat(@NotNull final Align align, @NotNull final int[] spacing)
+  {
+    return stream(spacing)
+        .mapToObj(space -> "%" + (align == Align.LEFT ? "-" : "") + (space + 2) + "s")
+        .collect(joining());
+  }
 
-	@NotNull
-	private static Optional<int[]> findSpacing(@NotNull final List<List<String>> rows)
-	{
-		return rows.stream()
-				   .map(row -> row.stream().mapToInt(String::length).toArray())
-				   .reduce((l, r) -> range(0, min(l.length, r.length)).map(i -> max(l[i], r[i])).toArray());
-	}
+  @NotNull
+  private static Optional<int[]> findSpacing(@NotNull final List<List<String>> rows)
+  {
+    return rows.stream()
+           .map(row -> row.stream().mapToInt(String::length).toArray())
+           .reduce((l, r) -> range(0, min(l.length, r.length)).map(i -> max(l[i], r[i])).toArray());
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/util/Futures.java
+++ b/src/main/java/me/clip/placeholderapi/util/Futures.java
@@ -35,49 +35,49 @@ import java.util.stream.Stream;
 public final class Futures
 {
 
-	private Futures()
-	{}
+  private Futures()
+  {}
 
 
-	public static <T> void onMainThread(@NotNull final Plugin plugin, @NotNull final CompletableFuture<T> future, @NotNull final BiConsumer<T, Throwable> consumer)
-	{
-		future.whenComplete((value, exception) -> {
-			if (Bukkit.isPrimaryThread())
-			{
-				consumer.accept(value, exception);
-			}
-			else
-			{
-				Bukkit.getScheduler().runTask(plugin, () -> consumer.accept(value, exception));
-			}
-		});
-	}
+  public static <T> void onMainThread(@NotNull final Plugin plugin, @NotNull final CompletableFuture<T> future, @NotNull final BiConsumer<T, Throwable> consumer)
+  {
+    future.whenComplete((value, exception) -> {
+      if (Bukkit.isPrimaryThread())
+      {
+        consumer.accept(value, exception);
+      }
+      else
+      {
+        Bukkit.getScheduler().runTask(plugin, () -> consumer.accept(value, exception));
+      }
+    });
+  }
 
 
-	@NotNull
-	public static <T> Collector<CompletableFuture<T>, ?, CompletableFuture<List<T>>> collector()
-	{
-		return Collectors.collectingAndThen(Collectors.toList(), Futures::of);
-	}
+  @NotNull
+  public static <T> Collector<CompletableFuture<T>, ?, CompletableFuture<List<T>>> collector()
+  {
+    return Collectors.collectingAndThen(Collectors.toList(), Futures::of);
+  }
 
 
-	@NotNull
-	public static <T> CompletableFuture<List<T>> of(@NotNull final Stream<CompletableFuture<T>> futures)
-	{
-		return of(futures.collect(Collectors.toList()));
-	}
+  @NotNull
+  public static <T> CompletableFuture<List<T>> of(@NotNull final Stream<CompletableFuture<T>> futures)
+  {
+    return of(futures.collect(Collectors.toList()));
+  }
 
-	@NotNull
-	public static <T> CompletableFuture<List<T>> of(@NotNull final Collection<CompletableFuture<T>> futures)
-	{
-		return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-								.thenApplyAsync($ -> awaitCompletion(futures));
-	}
+  @NotNull
+  public static <T> CompletableFuture<List<T>> of(@NotNull final Collection<CompletableFuture<T>> futures)
+  {
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenApplyAsync($ -> awaitCompletion(futures));
+  }
 
-	@NotNull
-	private static <T> List<T> awaitCompletion(@NotNull final Collection<CompletableFuture<T>> futures)
-	{
-		return futures.stream().map(CompletableFuture::join).collect(Collectors.toList());
-	}
+  @NotNull
+  private static <T> List<T> awaitCompletion(@NotNull final Collection<CompletableFuture<T>> futures)
+  {
+    return futures.stream().map(CompletableFuture::join).collect(Collectors.toList());
+  }
 
 }

--- a/src/main/java/me/clip/placeholderapi/util/Msg.java
+++ b/src/main/java/me/clip/placeholderapi/util/Msg.java
@@ -31,29 +31,29 @@ import java.util.stream.Collectors;
 public final class Msg
 {
 
-	public static void msg(@NotNull final CommandSender sender, @NotNull final String... messages)
-	{
-		if (messages.length == 0)
-		{
-			return;
-		}
+  public static void msg(@NotNull final CommandSender sender, @NotNull final String... messages)
+  {
+    if (messages.length == 0)
+    {
+      return;
+    }
 
-		sender.sendMessage(Arrays.stream(messages).map(Msg::color).collect(Collectors.joining("\n")));
-	}
+    sender.sendMessage(Arrays.stream(messages).map(Msg::color).collect(Collectors.joining("\n")));
+  }
 
-	public static void broadcast(@NotNull final String... messages)
-	{
-		if (messages.length == 0)
-		{
-			return;
-		}
+  public static void broadcast(@NotNull final String... messages)
+  {
+    if (messages.length == 0)
+    {
+      return;
+    }
 
-		Bukkit.broadcastMessage(Arrays.stream(messages).map(Msg::color).collect(Collectors.joining("\n")));
-	}
+    Bukkit.broadcastMessage(Arrays.stream(messages).map(Msg::color).collect(Collectors.joining("\n")));
+  }
 
-	public static String color(@NotNull final String text)
-	{
-		return ChatColor.translateAlternateColorCodes('&', text);
-	}
+  public static String color(@NotNull final String text)
+  {
+    return ChatColor.translateAlternateColorCodes('&', text);
+  }
 
 }


### PR DESCRIPTION
## Please read
Please make sure you checked the following:
- You checked the [Pull requests] page for any upcoming changes.
- You documented any public code that the end-user might use.
- You followed the [contributing file] 

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
> Provide additional information if needed.
<!-- Please type below this line -->
This PR improves the `/papi dump` command by listing the expansions differently.

Instead of
```
Expansions Registered:
  <author>:
    <expansion>: <version>
```
is it now:
```
Expansions Registered:
  <expansion> [Author: <author>, Version: <version>]
```

The brackets are dynamic in terms of distance from/to the expansion name and expansions are sorted by Author name.
See https://paste.helpch.at/uruliyizuc for an example.
The listed plugins also display in this form now for keeping it look the same.

Additionally, does this fix indents using Tabs instead of space characters, breaking the online view on GitHub and making it look worse than it should be.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->

[Pull requests]: https://github.com/PlaceholderAPI/PlaceholderAPI/pulls
[contributing file]: https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
