### PR TITLE
Fix trailing/leading space after placeholder once and for all

### DIFF
--- a/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
+++ b/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
@@ -100,11 +100,13 @@ public final class CharsReplacer implements Replacer {
 
       boolean identified = false;
       boolean oopsitsbad = true;
+      boolean hadSpace = false;
 
       while (++i < chars.length) {
         final char p = chars[i];
 
         if (p == ' ' && !identified) {
+          hadSpace = true;
           break;
         }
         if (p == closure.tail) {
@@ -137,7 +139,9 @@ public final class CharsReplacer implements Replacer {
           builder.append('_').append(parametersString);
         }
 
-        builder.append(' ');
+        if (hadSpace) {
+          builder.append(' ');
+        }
         continue;
       }
 
@@ -168,15 +172,7 @@ public final class CharsReplacer implements Replacer {
       builder.append(ChatColor.translateAlternateColorCodes('&', replacement));
     }
 
-    if (builder.length() == 0) {
-      return "";
-    }
-    char c = builder.charAt(builder.length() - 1);
-    if (c == ' ') {
-      return builder.substring(0, builder.length() - 1);
-    } else {
-      return builder.toString();
-    }
+    return builder.toString();
   }
 
 }


### PR DESCRIPTION
## Pull Request

### Type
- [x] Internal change (Doesn't affect end-user).

### Description
The code that is currently there I gave it to clip but eventually we figured out it didn't work properly. 
This commit fixes the issue. 

Some images before and after:
DeluxeChat config:
![jax_config](https://user-images.githubusercontent.com/37958105/89569470-694cf300-d82d-11ea-9a62-1b0c149c2969.png)

Before:
![jax_before](https://img.mrivanplays.com/DiscordCanary_gyyLuwiRa4.png)

After:
![jax_after](https://user-images.githubusercontent.com/37958105/89569544-871a5800-d82d-11ea-81c9-cf352dfa77ca.png)

DeluxeChat config:
![my_config](https://img.mrivanplays.com/sublime_text_CbaY5EghOM.png)

I don't have before, but the first picture shows it.
After:
![my_after](https://img.mrivanplays.com/javaw_FpTsoVljRx.png)
