### PR TITLE
Fix Statistic download information

### DIFF
--- a/wiki/Placeholders.md
+++ b/wiki/Placeholders.md
@@ -40,6 +40,7 @@ If the command itself isn't there and `NO DOWNLOAD COMMAND` instead is shown, th
 - **[Sound](#sound)**
 - **[Spectators](#spectators)**
 - **[SpeedPerSec](#speedpersec)**
+- **[Statistic](#statistic)**
 - **[Team](#team)**
 - **[World](#world)**
 ----

--- a/wiki/Placeholders.md
+++ b/wiki/Placeholders.md
@@ -40,7 +40,6 @@ If the command itself isn't there and `NO DOWNLOAD COMMAND` instead is shown, th
 - **[Sound](#sound)**
 - **[Spectators](#spectators)**
 - **[SpeedPerSec](#speedpersec)**
-- **[Statistic](#statistic)**
 - **[Team](#team)**
 - **[World](#world)**
 ----
@@ -887,10 +886,6 @@ This placeholder is for all players on the server.
 
 - ### **Statistic**
 > /papi ecloud download Statistic
-
-**For MC v1.12.2 or older:** <br />
-You'll have to download v1.7.0 manually: <br />
-Download the jar file from [the eCloud](https://api.extendedclip.com/expansions/statistic/versions/statistic-170/) then place it in your `plugins/PlaceholderAPI/expansions` folder. After that reload PlaceholderAPI `/papi reload`.
 
 Supports all statistics in [SpigotAPI](https://helpch.at/docs/1.13.1/org/bukkit/Statistic.html). `%statistic_<StatisticType>%`
 


### PR DESCRIPTION
## Pull Request

### Type
- [x] Wiki (Changes towards the [Wiki]).

### Description
Remove the outdated information about Statistic. The linked that used to be on the wiki, is linking to a version of Statistic that no longer works with newer version of PlaceholderAPI.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
