### PR TITLE
Adding Label commenter

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,0 +1,57 @@
+labels:
+  - name: 'Type: Issue (Expansion)'
+    labeled:
+      issue:
+        body: |-
+          Hello @{{ sender.login }},
+          
+          The issue you encountered is caused by an Expansion and not PlaceholderAPI itself.
+          This issue-tracker is reserved for Bug reports and feature requests towards PlaceholderAPI.
+          
+          Please report this issue to the Expansion's main issue-tracker.
+          
+          > *This is an automated response.*
+  - name: 'Type: Duplicate'
+    labeled:
+      issue:
+        body: |-
+          Your issue is already known and a separate issue with the exact same report/feature request already exist.
+          
+          Please comment on the already existing issue with your information instead of opening your own.
+          
+          > *This is an automated response.*
+        action: close
+  - name: 'Problem: More info required'
+    labeled:
+      issue:
+        body: |-
+          Hello @{{ sender.login }},
+          
+          Your issue unfortunately lacks certain information that we require in order to help you with your issue.
+          Please make sure you provide the following information:
+          
+          - Currently used Versions of your server and PlaceholderAPI
+          - Currently installed Expansions
+          - Currently installed Plugins
+          
+          The easiest way to provide those information is through the `/papi dumb` command which posts the required information and gives a URL to share.
+          
+          > *This is an automated response.*
+    unlabeled:
+      issue:
+        body: |-
+          Thank you for providing additional information.
+          We will take a look at the issue you encounter and come back to you with a possible solution.
+  - name: 'Type: Invalid'
+    labeled:
+      issue:
+        body: |-
+          Your issue has beeen marked as invalid.
+          This means that it either doesn't follow any provided template, or isn't related to PlaceholderAPI in any way.
+          
+          Please make sure to use one of the issue templates and provide the requested information.
+          Currently available Templates are:
+          
+          - [Bug Report](https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md)
+          - [Feature Request](https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=feature_request.md)
+        action: close

--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -54,6 +54,8 @@ labels:
           
           - [Bug Report](https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md)
           - [Feature Request](https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=feature_request.md)
+          
+          > *This is an automated response.*
         action: close
   - name: 'Target: Wiki'
     labeled:
@@ -70,3 +72,5 @@ labels:
           - You followed the general Styling Guidelines mentioned in the wiki's [README](https://github.com/PlaceholderAPI/PlaceholderAPI/blob/docs/wiki/wiki/README.md) file.
           
           If you have any questions about submitting a PR for the wiki or have any other questions don't hesitate to ask us about it.
+          
+          > *This is an automated response.*

--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -55,3 +55,18 @@ labels:
           - [Bug Report](https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md)
           - [Feature Request](https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=feature_request.md)
         action: close
+  - name: 'Target: Wiki'
+    labeled:
+      issue:
+        body: |-
+          Hello @{{ sender.login }},
+          
+          Thank you for reaching out to us about the wiki.
+          We would like to inform you, that you are now able to directly commit your changes to the wiki through a Pull request.
+          When doing so, make sure you follow these steps:
+          
+          - The Pull request targets the [`docs/wiki`](https://github.com/PlaceholderAPI/PlaceholderAPI/tree/docs/wiki) branch of the Repository.
+          - You only made changes to the files inside the `wiki` folder.
+          - You followed the general Styling Guidelines mentioned in the wiki's [README](https://github.com/PlaceholderAPI/PlaceholderAPI/blob/docs/wiki/wiki/README.md) file.
+          
+          If you have any questions about submitting a PR for the wiki or have any other questions don't hesitate to ask us about it.

--- a/.github/workflows/label_comment.yml
+++ b/.github/workflows/label_comment.yml
@@ -1,0 +1,24 @@
+name: Comment
+
+on:
+  issues:
+    types:
+    - labeled
+    - unlabeled
+  pull_request:
+    types:
+    - labeled
+    - unlabeled
+
+jobs:
+  give_comment:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        ref: master
+    - name: Send Issue/Pull request comment
+      uses: peaceiris/actions-label-commenter@v1.5.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [x] Other: Issues/Pull requests <!-- Use this if none of the above matches your request -->

### Description
This adds a GitHub Action, which allows us to send canned responses based on labels we (un)assign to issues and Pull requests.

For example could we send a Comment to an issue when the `Type: Issue (Expansion)` label is assigned, informing about the issue being caused by an Expansion.

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
