### PR TITLE
Fix PlaceholderAPI sending update notifications on Join despite it being disabled

### DIFF
--- a/src/main/java/me/clip/placeholderapi/listeners/JoinListener.java
+++ b/src/main/java/me/clip/placeholderapi/listeners/JoinListener.java
@@ -1,0 +1,41 @@
+package me.clip.placeholderapi.listeners;
+
+import me.clip.placeholderapi.PlaceholderAPI;
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
+import me.clip.placeholderapi.configuration.PlaceholderAPIConfig;
+import me.clip.placeholderapi.updatechecker.UpdateChecker;
+import me.clip.placeholderapi.util.Msg;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.jetbrains.annotations.NotNull;
+
+public final class JoinListener implements Listener {
+
+  @NotNull
+  private final PlaceholderAPIConfig config;
+  
+  @NotNull
+  private final UpdateChecker updateChecker;
+
+  public JoinListener(@NotNull final PlaceholderAPIPlugin plugin, @NotNull final UpdateChecker updateChecker) {
+    this.config = plugin.getPlaceholderAPIConfig();
+    
+    this.updateChecker = updateChecker;
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerJoin(@NotNull final PlayerJoinEvent event) {
+    Player player = event.getPlayer();
+    if (player.hasPermission("placeholderapi.updatenorify") && config.checkUpdates()) {
+      Msg.msg(player, 
+              "&bAn update for &fPlaceholder&7API &e(&fPlaceholder&7API &fv" + updateChecker.getSpigotVersion()
+                      + "&e)"
+              , "&bis available at &ehttps://www.spigotmc.org/respirces/placeholderapi." + updateChecker.getResourceId() 
+                      + "/");
+    }
+  }
+}

--- a/src/main/java/me/clip/placeholderapi/updatechecker/UpdateChecker.java
+++ b/src/main/java/me/clip/placeholderapi/updatechecker/UpdateChecker.java
@@ -25,6 +25,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import javax.net.ssl.HttpsURLConnection;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
+import me.clip.placeholderapi.listeners.JoinListener;
 import me.clip.placeholderapi.util.Msg;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -51,6 +52,10 @@ public class UpdateChecker implements Listener {
 
   public String getSpigotVersion() {
     return spigotVersion;
+  }
+  
+  public int getResourceId(){
+    return RESOURCE_ID;
   }
 
   public void fetch() {
@@ -80,7 +85,7 @@ public class UpdateChecker implements Listener {
             .info("An update for PlaceholderAPI (v" + getSpigotVersion() + ") is available at:");
         plugin.getLogger()
             .info("https://www.spigotmc.org/resources/placeholderapi." + RESOURCE_ID + "/");
-        Bukkit.getPluginManager().registerEvents(this, plugin);
+        Bukkit.getPluginManager().registerEvents(new JoinListener(plugin, this), plugin);
       });
     });
   }
@@ -101,16 +106,5 @@ public class UpdateChecker implements Listener {
     }
 
     return version.replaceAll("\\.", "");
-  }
-
-  @EventHandler(priority = EventPriority.MONITOR)
-  public void onJoin(PlayerJoinEvent e) {
-    if (e.getPlayer().hasPermission("placeholderapi.updatenotify")) {
-      Msg.msg(e.getPlayer(),
-          "&bAn update for &fPlaceholder&7API &e(&fPlaceholder&7API &fv" + getSpigotVersion()
-              + "&e)"
-          , "&bis available at &ehttps://www.spigotmc.org/resources/placeholderapi." + RESOURCE_ID
-              + "/");
-    }
   }
 }


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
Right now does PAPI send an update notification to a joining player, even if "check_updates" is set to false. This is fixed with this PR.

Additionall was the Join listener moved from the UpdateChecker class to its own class in the listener folder (Makes more sense)

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
