### PR TITLE
Add "all" argument for parse command

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
@@ -101,6 +101,7 @@ public final class CommandParse extends PlaceholderCommand {
       }
 
       player = ((Player) sender);
+    } else if ("all".equalsIgnoreCase(params.get(0))) {
     } else {
       final OfflinePlayer target = resolvePlayer(params.get(0));
       if (target == null) {

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.Unmodifiable;
 public final class CommandParse extends PlaceholderCommand {
 
   public CommandParse() {
-    super("parse", "bcparse", "parserel", "cmdparse");
+    super("parse", "bcparse", "parserel", "cmdparse", "parseall");
   }
 
 


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
Adds an `all` argument to the parse command which allows parsing the provided String towards all (online) players and returning their info.

Closes #441 


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
