### PR TITLE
Add missing getBoolean method

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
@@ -199,6 +199,12 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
     final ConfigurationSection section = getConfigSection();
     return section == null ? Collections.emptyList() : section.getStringList(path);
   }
+  
+  @NotNull
+  public final boolean getBoolean(@NotNull final String path, final boolean def) {
+    final ConfigurationSection section = getConfigSection();
+    return section == null ? def : section.getBoolean(path, def);
+  }
 
   public final boolean configurationContains(@NotNull final String path) {
     final ConfigurationSection section = getConfigSection();


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
This adds a `getBoolean(String, boolean)` method to the PlaceholderExpansion class to allow people having booleans set through Configurable's getDefaults, to then check against.

Why wasn't this added?

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
