### PR TITLE
Added event when all expansions are loaded for developers.

### DIFF
--- a/src/main/java/me/clip/placeholderapi/events/ExpansionsLoadedEvent.java
+++ b/src/main/java/me/clip/placeholderapi/events/ExpansionsLoadedEvent.java
@@ -6,9 +6,7 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This event is ran when all expansions are loaded.
- * This is done when reloading config, on plugin start and on server load.
- * @author jacobbordas (@ignissak)
+ * This event is called when all expansions are loaded (when reloading config, on plugin start and on server load).
  */
 public class ExpansionsLoadedEvent extends Event {
 

--- a/src/main/java/me/clip/placeholderapi/events/ExpansionsLoadedEvent.java
+++ b/src/main/java/me/clip/placeholderapi/events/ExpansionsLoadedEvent.java
@@ -1,0 +1,28 @@
+package me.clip.placeholderapi.events;
+
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event is ran when all expansions are loaded.
+ * This is done when reloading config, on plugin start and on server load.
+ * @author jacobbordas (@ignissak)
+ */
+public class ExpansionsLoadedEvent extends Event {
+
+    @NotNull
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -322,8 +322,7 @@ public final class LocalExpansionManager implements Listener {
           registered == 0 ? "&6No expansions were registered!"
               : registered + "&a placeholder hooks successfully registered!");
 
-      final ExpansionsLoadedEvent event = new ExpansionsLoadedEvent();
-      Bukkit.getPluginManager().callEvent(event);
+      Bukkit.getPluginManager().callEvent(new ExpansionsLoadedEvent());
     });
   }
 

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -36,6 +36,7 @@ import java.util.logging.Level;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.events.ExpansionRegisterEvent;
 import me.clip.placeholderapi.events.ExpansionUnregisterEvent;
+import me.clip.placeholderapi.events.ExpansionsLoadedEvent;
 import me.clip.placeholderapi.expansion.Cacheable;
 import me.clip.placeholderapi.expansion.Cleanable;
 import me.clip.placeholderapi.expansion.Configurable;
@@ -320,6 +321,9 @@ public final class LocalExpansionManager implements Listener {
       Msg.msg(sender,
           registered == 0 ? "&6No expansions were registered!"
               : registered + "&a placeholder hooks successfully registered!");
+
+      final ExpansionsLoadedEvent event = new ExpansionsLoadedEvent();
+      Bukkit.getPluginManager().callEvent(event);
     });
   }
 


### PR DESCRIPTION
Event `ExpansionsLoadedEvent` is called on the end of `LocalExpansionManager#registerAll()`.
Resolves https://github.com/PlaceholderAPI/PlaceholderAPI/issues/444