### PR TITLE
Fix wrong expansion get in /papi info

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandInfo.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandInfo.java
@@ -47,7 +47,7 @@ public final class CommandInfo extends PlaceholderCommand {
     }
 
     final PlaceholderExpansion expansion = plugin.getLocalExpansionManager()
-        .findExpansionByName(params.get(0)).orElse(null);
+        .findExpansionByIdentifier(params.get(0)).orElse(null);
     if (expansion == null) {
       Msg.msg(sender,
           "&cThere is no expansion loaded with the identifier: &f" + params.get(0));


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
Fixes the issue where `/papi info <expansion>` would return invalid information when suggesting expansions by identifier, but searching by name (Which can differ)

Closes #469 


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
