### PR TITLE
Remove Gson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ repositories {
 }
 
 dependencies {
-    implementation "com.google.code.gson:gson:2.8.6"
     implementation "org.bstats:bstats-bukkit:1.5"
 
     compileOnly "org.spigotmc:spigot-api:1.16.2-R0.1-SNAPSHOT"
@@ -48,7 +47,6 @@ shadowJar {
     archiveClassifier.set("")
 
     relocate "org.bstats", "me.clip.placeholderapi.metrics"
-    relocate "com.google.gson", "me.clip.placeholderapi.libs.gson"
 }
 
 license {

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandDump.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandDump.java
@@ -21,7 +21,17 @@
 package me.clip.placeholderapi.commands.impl.local;
 
 import com.google.common.io.CharStreams;
-import com.google.gson.JsonParser;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
+import me.clip.placeholderapi.commands.PlaceholderCommand;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import me.clip.placeholderapi.util.Msg;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -41,19 +51,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
-import me.clip.placeholderapi.PlaceholderAPIPlugin;
-import me.clip.placeholderapi.commands.PlaceholderCommand;
-import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import me.clip.placeholderapi.util.Msg;
-import org.bukkit.command.CommandSender;
-import org.bukkit.plugin.Plugin;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Unmodifiable;
 
 public final class CommandDump extends PlaceholderCommand {
 
   @NotNull
   private static final String URL = "https://paste.helpch.at/";
+
+  @NotNull
+  private static final Gson gson = new Gson();
 
   @NotNull
   private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter
@@ -102,9 +107,8 @@ public final class CommandDump extends PlaceholderCommand {
 
         try (final InputStream stream = connection.getInputStream()) {
           //noinspection UnstableApiUsage
-          final String json = CharStreams
-              .toString(new InputStreamReader(stream, StandardCharsets.UTF_8));
-          return JsonParser.parseString(json).getAsJsonObject().get("key").getAsString();
+          final String json = CharStreams.toString(new InputStreamReader(stream, StandardCharsets.UTF_8));
+          return gson.fromJson(json, JsonObject.class).get("key").getAsString();
         }
       } catch (final IOException ex) {
         throw new CompletionException(ex);


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
I made this PR now to finally get this rolling.
As described in #477 does PAPI have a chance of messing up bStats which may or may not break stats of all the other plugins that use bStats.
From what I gathered in the issue is the problem the relocated gson and the only reason gson is there is because of 1.7 support.

I say fuck 1.7! That version doesn't have any real reason to be supported on our end and finding a complicated solution (like making a separate jar... why?) just to still support it is imo not good at all.

This is a draft to keep a sort of discussion running so that we can (finally) decide on a solution. If there is a better solution without making PAPI too overcomplicated in terms of maintenance should this be mentioned.
I may open this for merge once we finally go to a proper point but my opinion is to finally drop 1.7 support. It's not worth the trouble in any way.

Closes #477 


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
