### PR TITLE
Fixing issues for logging when Expansion doesn't contain any classes.

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -358,12 +358,8 @@ public final class LocalExpansionManager implements Listener {
         throw ((LinkageError) ex.getCause());
       }
       
-      /* Currently causes an exception when clazz is null due to an expansion not having any.
-       * 
-       *plugin.getLogger()
-       *    .log(Level.SEVERE, "Failed to load placeholder expansion from class: " + clazz.getName(),
-       *        ex);
-       */
+      plugin.getLogger().warning("There was an issue with loading an expansion");
+      
       return null;
     }
   }


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes #515
Closes #516

When an expansion doesn't contain any class files (Being it malformed download or broken build) will PlaceholderAPI throw an exception when it attempts to log the failed loading of an expansion, essentially breaking the logging. Please see #515 for full context.

This Pull request is NOT finished yet as we still need to find a solution to fix this issue while still logging the failed load of an expansion.

In addition have some of the lines been updated to not provide missinformation (Often such errors happen due to a missing dependency and not an outdated expansion)

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
