### PR TITLE
Fix resolvePlayer method

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
@@ -212,12 +212,15 @@ public final class CommandParse extends PlaceholderCommand {
   @Nullable
   private OfflinePlayer resolvePlayer(@NotNull final String name) {
     OfflinePlayer target = Bukkit.getPlayer(name);
-
+    
     if (target == null) {
-      target = Bukkit.getOfflinePlayer(name); // this is probably not a great idea.
+      // Not the best option, but Spigot doesn't offer a good replacement (as usual)
+      target = Bukkit.getOfflinePlayer(name);
+      
+      return target.hasPlayedBefore() ? target : null;
     }
 
-    return target.hasPlayedBefore() ? target : null;
+    return target;
 
   }
 

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
@@ -211,7 +211,7 @@ public final class CommandParse extends PlaceholderCommand {
 
   @Nullable
   private OfflinePlayer resolvePlayer(@NotNull final String name) {
-    OfflinePlayer target = Bukkit.getPlayer(name);
+    OfflinePlayer target = Bukkit.getPlayerExact(name);
     
     if (target == null) {
       // Not the best option, but Spigot doesn't offer a good replacement (as usual)


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes #527 <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->

Improves the `resolvePlayer(String)` method by only checking if the player played before when the player was null for `getPlayer` and therefore a OfflinePlayer needs to be retrieved.
If the `getPlayer` method doesn't return null will the retrieved entity just be returned as it should be a valid online player to use.
Why was this stupid `hasPlayedBefore` check even made at the very end?

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
