### PR TITLE
🔧 update wrong (time_played) statistic types on wiki

### DIFF
--- a/wiki/Placeholders.md
+++ b/wiki/Placeholders.md
@@ -912,10 +912,10 @@ Other statistics
 %statistic_hours_played%
 %statistic_days_played%
 %statistic_time_played%
-%statistic_seconds_played_remaining%
-%statistic_minutes_played_remaining%
-%statistic_hours_played_remaining%
-%statistic_days_played_remaining%
+%statistic_time_played:seconds%
+%statistic_time_played:minutes%
+%statistic_time_played:hours%
+%statistic_time_played:days%
 %statistic_animals_bred%
 %statistic_armor_cleaned%
 %statistic_banner_cleaned%


### PR DESCRIPTION
## Pull Request

### Type
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ 

### Description
As I was looking for a way to show _remaining_ time in hours, minutes, and/or seconds, I opened a ticket here and got a reply "it's not a direct issue with us, move to statistic expansion" _which is basically_ related to here. Wrong documentation is your business, now that I saw these types on code, I am able to get what I need but for future reference and for other people's sake, leaving a PR for you. [Check the code here.](https://github.com/PlaceholderAPI/Statistics-Expansion/blob/1ccc68a7ccc939815ebf2c571995a9640398db8c/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsExpansion.java#L106)

Closes [issue #24 on Statistics Expansion repository](https://github.com/PlaceholderAPI/Statistics-Expansion/issues/24) 

[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
