### PR TITLE
First attempt at adding Hex support.

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionList.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudExpansionList.java
@@ -46,7 +46,7 @@ import me.clip.placeholderapi.expansion.cloud.CloudExpansion;
 import me.clip.placeholderapi.libs.JSONMessage;
 import me.clip.placeholderapi.util.Format;
 import me.clip.placeholderapi.util.Msg;
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/me/clip/placeholderapi/libs/JSONMessage.java
+++ b/src/main/java/me/clip/placeholderapi/libs/JSONMessage.java
@@ -27,8 +27,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.Vector;
+
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 /**
@@ -37,7 +38,7 @@ import org.bukkit.entity.Player;
  *
  * @author Rayzr
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings("ALL")
 public class JSONMessage {
 
   private static final BiMap<ChatColor, String> stylesToNames;
@@ -45,24 +46,11 @@ public class JSONMessage {
   static {
     ImmutableBiMap.Builder<ChatColor, String> builder = ImmutableBiMap.builder();
     for (final ChatColor style : ChatColor.values()) {
-      if (!style.isFormat()) {
+      if (style.getColor() != null) {
         continue;
       }
 
-      String styleName;
-      switch (style) {
-        case MAGIC:
-          styleName = "obfuscated";
-          break;
-        case UNDERLINE:
-          styleName = "underlined";
-          break;
-        default:
-          styleName = style.name().toLowerCase();
-          break;
-      }
-
-      builder.put(style, styleName);
+      builder.put(style, style.getName());
     }
     stylesToNames = builder.build();
   }
@@ -173,10 +161,6 @@ public class JSONMessage {
    * @param players The players you want to send this to
    */
   public void send(Player... players) {
-    if (ReflectionHelper.MAJOR_VER >= 16) {
-//            ReflectionHelper.sendTextPacket(toString(), players);
-//            return;
-    }
 
     ReflectionHelper.sendPacket(ReflectionHelper.createTextPacket(toString()), players);
   }
@@ -221,11 +205,11 @@ public class JSONMessage {
    * @return This {@link JSONMessage} instance
    */
   public JSONMessage color(ChatColor color) {
-    if (!color.isColor()) {
-      throw new IllegalArgumentException(color.name() + " is not a color.");
+    if (color.getColor() == null) {
+      throw new IllegalArgumentException(color.getName() + " is not a color.");
     }
 
-    last().setColor(color);
+    last().setColor(color.getName());
     return this;
   }
 
@@ -1041,16 +1025,6 @@ public class JSONMessage {
 
     /**
      * @param color The color to set
-     * @deprecated Use {@link #setColor(String)} instead
-     */
-    @Deprecated
-    public void setColor(ChatColor color) {
-      setColor(color == null ? null : color.name().toLowerCase());
-      setLegacyColor(color);
-    }
-
-    /**
-     * @param color The color to set
      */
     public void setColor(String color) {
       if (color != null && color.isEmpty()) {
@@ -1082,8 +1056,8 @@ public class JSONMessage {
       if (style == null) {
         throw new IllegalArgumentException("Style cannot be null!");
       }
-      if (!style.isFormat()) {
-        throw new IllegalArgumentException(style.name() + " is not a style!");
+      if (style.getColor() != null) {
+        throw new IllegalArgumentException(style.getName() + " is not a style!");
       }
       styles.add(style);
     }

--- a/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
+++ b/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
@@ -53,10 +53,10 @@ public final class CharsReplacer implements Replacer {
       if (l == '&' && ++i < chars.length) {
         final char c = Character.toLowerCase(chars[i]);
 
-        if (c != '0' && c != '1' && c != '2' && c != '3' && c != '4' && c != '5' && c != '6'
-            && c != '7' && c != '8' && c != '9' && c != 'a' && c != 'b' && c != 'c' && c != 'd'
-            && c != 'e' && c != 'f' && c != 'k' && c != 'l' && c != 'm' && c != 'n' && c != 'o' && c != 'r'
-            && c != 'x' && c != '#') {
+        if (c != '0' && c != '1' && c != '2' && c != '3' && c != '4' && c != '5' && c != '6' &&
+            c != '7' && c != '8' && c != '9' && c != 'a' && c != 'b' && c != 'c' && c != 'd' &&
+            c != 'e' && c != 'f' && c != 'k' && c != 'l' && c != 'm' && c != 'n' && c != 'o' &&
+            c != 'r' && c != 'x' && c != '#') {
           builder.append(l).append(chars[i]);
         } else {
           builder.append(ChatColor.COLOR_CHAR);
@@ -87,8 +87,9 @@ public final class CharsReplacer implements Replacer {
 
             final char x = Character.toLowerCase(chars[i + j]);
             // Make sure the characters are valid hex options (0-9, a-f)
-            if (x != '0' && x != '1' && x != '2' && x != '3' && x != '4' && x != '5' && x != '6' && x != '7'
-               && x != '8' && x != '9' && x != 'a' && x != 'b' && x != 'c' && x != 'd' && x != 'e' && x != 'f') {
+            if (x != '0' && x != '1' && x != '2' && x != '3' && x != '4' && x != '5' && x != '6' &&
+                x != '7' && x != '8' && x != '9' && x != 'a' && x != 'b' && x != 'c' && x != 'd' &&
+                x != 'e' && x != 'f') {
               break;
             }
             

--- a/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
+++ b/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
@@ -22,7 +22,7 @@ package me.clip.placeholderapi.replacer;
 
 import java.util.function.Function;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,12 +56,12 @@ public final class CharsReplacer implements Replacer {
         if (c != '0' && c != '1' && c != '2' && c != '3' && c != '4' && c != '5' && c != '6'
             && c != '7' && c != '8' && c != '9' && c != 'a' && c != 'b' && c != 'c' && c != 'd'
             && c != 'e' && c != 'f' && c != 'k' && c != 'l' && c != 'm' && c != 'n' && c != 'o' && c != 'r'
-            && c != 'x') {
+            && c != 'x' && c != '#') {
           builder.append(l).append(chars[i]);
         } else {
           builder.append(ChatColor.COLOR_CHAR);
 
-          if (c != 'x') {
+          if (c != 'x' && c != '#') {
             builder.append(chars[i]);
             continue;
           }
@@ -71,8 +71,13 @@ public final class CharsReplacer implements Replacer {
             builder.append('&').append(chars[i]);
             continue;
           }
-
-          builder.append(c);
+          
+          // Turn the # into an X to support Hex colors
+          if (c == '#') {
+            builder.append('x');
+          } else {
+            builder.append(c);
+          }
 
           int j = 0;
           while (++j <= 6) {
@@ -80,7 +85,13 @@ public final class CharsReplacer implements Replacer {
               break;
             }
 
-            final char x = chars[i + j];
+            final char x = Character.toLowerCase(chars[i + j]);
+            // Make sure the characters are valid hex options (0-9, a-f)
+            if (x != '0' && x != '1' && x != '2' && x != '3' && x != '4' && x != '5' && x != '6' && x != '7'
+               && x != '8' && x != '9' && x != 'a' && x != 'b' && x != 'c' && x != 'd' && x != 'e' && x != 'f') {
+              break;
+            }
+            
             builder.append(ChatColor.COLOR_CHAR).append(x);
           }
 

--- a/src/main/java/me/clip/placeholderapi/replacer/RegexReplacer.java
+++ b/src/main/java/me/clip/placeholderapi/replacer/RegexReplacer.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/me/clip/placeholderapi/util/Msg.java
+++ b/src/main/java/me/clip/placeholderapi/util/Msg.java
@@ -22,8 +22,9 @@ package me.clip.placeholderapi.util;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
+
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes #573

Adds `&#<hex>` color format to PAPI by using the BungeeCord ChatColor class.

The CharReplacer has been updated to acknowledge the new color syntax and to also only translate to valid hex colors. Right now tho does it remove the `&x` from the start, but I'm not sure how to correct this or IF it should be corrected at all.

JSONMessage class also was updated to support the ChatColor class of BungeeCord and from my basic testing did it work.

Here's the latest Jar for you to try out, if you like.
https://cdn.discordapp.com/attachments/584040473186926623/811647295052447814/PlaceholderAPI-2.10.10-DEV-null.jar

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
