### PR TITLE
Remove color formatting from placeholder parser

### DIFF
--- a/src/main/java/me/clip/placeholderapi/events/ExpansionsLoadedEvent.java
+++ b/src/main/java/me/clip/placeholderapi/events/ExpansionsLoadedEvent.java
@@ -26,7 +26,7 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Indicates that <b>all</b> {@link PlaceholderExpansion PlayceholderExpansions}
+ * Indicates that <b>all</b> {@link me.clip.placeholderapi.expansion.PlaceholderExpansion PlayceholderExpansions}
  * have been loaded.
  * <br/>This event is fired on Server load and when reloading the
  * confiuration.

--- a/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
@@ -22,7 +22,6 @@ package me.clip.placeholderapi.expansion;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.PlaceholderHook;
 import org.bukkit.Bukkit;
@@ -276,7 +275,6 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
    * @param def The default boolean to return when the ConfigurationSection is null
    * @return boolean from the provided path or the default one provided
    */
-  @NotNull
   public final boolean getBoolean(@NotNull final String path, final boolean def) {
     final ConfigurationSection section = getConfigSection();
     return section == null ? def : section.getBoolean(path, def);

--- a/src/main/java/me/clip/placeholderapi/expansion/cloud/CloudExpansion.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/cloud/CloudExpansion.java
@@ -171,7 +171,7 @@ public class CloudExpansion {
     this.versions = versions;
   }
 
-  public class Version {
+  public static class Version {
 
     private String url, version, release_notes;
 

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -22,6 +22,7 @@ package me.clip.placeholderapi.expansion.manager;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.util.stream.Stream;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.events.ExpansionRegisterEvent;
 import me.clip.placeholderapi.events.ExpansionUnregisterEvent;
@@ -326,7 +327,12 @@ public final class LocalExpansionManager implements Listener {
 
   @NotNull
   public CompletableFuture<@NotNull List<@Nullable Class<? extends PlaceholderExpansion>>> findExpansionsOnDisk() {
-    return Arrays.stream(folder.listFiles((dir, name) -> name.endsWith(".jar")))
+    File[] files = folder.listFiles(((dir, name) -> name.endsWith(".jar")));
+    if (files == null) {
+      files = new File[0]; // listFiles can be null, so we create an empty array.
+    }
+    
+    return Arrays.stream(files)
         .map(this::findExpansionInFile)
         .collect(Futures.collector());
   }


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
This was made with a huge help from Crypto Morin.

This PR **removes** the color code parsing from PlaceholderAPI's CharsReplacer.
It shouldn't be the Job of PlaceholderAPI to parse the colors since that only causes unwanted extra bloat and not needed work to maintain, especially with Hex colors in 1.16.

PlaceholderAPI should focus on parsing the placeholders themself. If the dev of an expansion wants translated colors should they do it themself.

Some other small changes:
- Removed invalid `@NotNull` annotation from `getBoolean` method since it can't be applied to primitives.
- Made Version a static class
- Added some checks to `findExpansionsOnDisk` for the case that the returned `File` array is null.

This is obviously a breaking change so a merge should only be made after it has been discussed AND when PAPI is ready for the next major release.


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
