### PR TITLE
Fixed issue with expansions not being able to access their resources

### DIFF
--- a/src/main/java/me/clip/placeholderapi/util/FileUtil.java
+++ b/src/main/java/me/clip/placeholderapi/util/FileUtil.java
@@ -67,8 +67,11 @@ public class FileUtil {
         }
       }
     }
-
-    return classes.isEmpty() ? null : classes.get(0);
+    if (classes.isEmpty()) {
+        loader.close();
+        return null;
+    }
+    return classes.get(0);
   }
 
 }

--- a/src/main/java/me/clip/placeholderapi/util/FileUtil.java
+++ b/src/main/java/me/clip/placeholderapi/util/FileUtil.java
@@ -42,13 +42,11 @@ public class FileUtil {
     }
 
     final URL jar = file.toURI().toURL();
-
+    final URLClassLoader loader = new URLClassLoader(new URL[]{jar}, clazz.getClassLoader());
     final List<String> matches = new ArrayList<>();
     final List<Class<? extends T>> classes = new ArrayList<>();
 
-    try (final JarInputStream stream = new JarInputStream(
-        jar.openStream()); final URLClassLoader loader = new URLClassLoader(new URL[]{jar},
-        clazz.getClassLoader())) {
+    try (final JarInputStream stream = new JarInputStream(jar.openStream())) {
       JarEntry entry;
       while ((entry = stream.getNextJarEntry()) != null) {
         final String name = entry.getName();


### PR DESCRIPTION
## Pull Request

### Type
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
URLClassLoaders created for expansions were automatically closed earlier due to being declared with try-with-resource, this meant that expansions couldnt access their resources without weird workarounds. 
Moved it out of try-with-resources and closed the ClassLoader specifically only if no expansion was found.

Closes N/A


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
