### PR TITLE
update BetonQuest docs link

### DIFF
--- a/wiki/Placeholders.md
+++ b/wiki/Placeholders.md
@@ -1716,7 +1716,7 @@ Please see [this discussion][list] for a list of all expansions officially maint
 - ### **[BetonQuest](https://www.spigotmc.org/resources/2117/)**
   > NO DOWNLOAD COMMAND
   
-  Please refer to the [official documentation](https://betonquest.github.io/BetonQuest/versions/dev/User-Documentation/Compatibility/#placeholderapi) for more info.
+  Please refer to the [official documentation](https://docs.betonquest.org/RELEASE/User-Documentation/Compatibility/#placeholderapi) for more info.
   
   ```
   %betonquest_<variable>%


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [X] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
I updated the docs link for the BetonQuest plugin. It was outdated and did not work anymore.

Closes N/A 


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
