### PR TITLE
Switch to differen wiki action

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -27,26 +27,10 @@ jobs:
       - name: 'Checkout Code'
         uses: actions/Checkout@v2
       - name: 'Update Wiki'
-        uses: docker://decathlon/wiki-page-creator-action:latest
+        uses: Andrew-Chen-Wang/github-wiki-action@v2
         env:
-          #
-          # We can use the E-Mail and Name of the GitHub Actions account
-          # for our convenience.
-          #
-          ACTION_MAIL: 'actions@github.com'
-          ACTION_NAME: 'github-actions[bot]'
-          #
-          # We (sadly) have to use a PAT (Personal Access Token) for this action.
-          #
-          GH_PAT: '${{ secrets.WORKFLOWPAT }}'
-          OWNER: 'PlaceholderAPI'
-          REPO_NAME: 'PlaceholderAPI'
-          #
-          # We only want to target files in the wiki folder
-          #
-          MD_FOLDER: 'wiki'
-          WIKI_PUSH_MESSAGE: '${{ github.event.commits[0].message }}'
-          #
-          # We skip/ignore the README.md file in the Wiki folder
-          #
-          SKIP_MD: README.md
+          WIKI_DIR: wiki/
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_EMAIL: 'actions@github.com'
+          GH_NAME: 'github-actions[bot]'
+          EXCLUDED_FILES: 'README.md'


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->

Updates the Wiki Workflow to use https://github.com/Andrew-Chen-Wang/github-wiki-action instead. This action seems to not require a personal access token and instead can work with the normal GitHub token.

To my knowledge does it also allow pushing folders to the wiki, which would in return allow us to keep files hosted in the same folder and use relative links.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
