### PR TITLE
Add release.yml for automatic release drafts

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+#
+# This file is used to automatically draft new release changelogs in GitHub.
+# Read more: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+changelog:
+  exclude:
+    labels:
+    - 'Action: No Changelog'
+  categories:
+  - title: 'Breaking Changes'
+    labels:
+    - 'Type: Breaking'
+  - title: 'Additions'
+    labels:
+    - 'Type: New Feature'
+  - title: 'Changes'
+    labels:
+    - 'Type: Enhancement'
+  - title: 'Fixes'
+    labels:
+    - 'Type: Bugfix'
+  - title: 'Other changes'
+    labels:
+    - '*' # Catch every other PR not labeled with an "exclude" label.


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [x] Other: Repository <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
GitHub added the ability to automatically create changelogs for new releases by clicking a button in the release drafter.
This feature can be customized using a `release.yml` file inside the `.github` folder.

This PR adds such a file to enable the automatic release drafting feature for this repository. This should help us keep track of all PRs made towards PlaceholderAPI.

Currently implemented categories (and corresponding labels:

- Breaking Change
  - Label: `Type: Breaking`
- Additions
  - Label: `Type: New Feature`
- Changes
  - Label: `Type: Enhancement`
- Fixes
  - Label: `Type: Bugfix`
- Other Changes
  - Label: `*` (This is a catch-all for all not listed PR labels, excluding PRs with labels in "exclude")

There is also a `Action: No Changelog` label configured that allows to exclude certain PRs from being included (Useful for PRs that Sync branches.

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
