### PR TITLE
Improve expansion sorting in /papi dump

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandDump.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandDump.java
@@ -106,7 +106,6 @@ public final class CommandDump extends PlaceholderCommand {
         }
 
         try (final InputStream stream = connection.getInputStream()) {
-          //noinspection UnstableApiUsage
           final String json = CharStreams.toString(new InputStreamReader(stream, StandardCharsets.UTF_8));
           return gson.fromJson(json, JsonObject.class).get("key").getAsString();
         }
@@ -134,8 +133,10 @@ public final class CommandDump extends PlaceholderCommand {
     final List<PlaceholderExpansion> expansions = plugin.getLocalExpansionManager()
         .getExpansions()
         .stream()
-        .sorted(Comparator.comparing(PlaceholderExpansion::getIdentifier))
-        .sorted(Comparator.comparing(PlaceholderExpansion::getAuthor))
+        .sorted(
+            Comparator.comparing(PlaceholderExpansion::getIdentifier)
+                      .thenComparing(PlaceholderExpansion::getAuthor)
+        )
         .collect(Collectors.toList());
 
     int size = 0;
@@ -167,10 +168,15 @@ public final class CommandDump extends PlaceholderCommand {
         .getExpansionsFolder()
         .list((dir, name) -> name.toLowerCase().endsWith(".jar"));
 
-    for (final String jar : jars) {
-      builder.append("  ")
-          .append(jar)
-          .append('\n');
+
+    if (jars == null) {
+      builder.append("  WARN: Jars array was empty!");
+    } else {
+      for (final String jar : jars) {
+        builder.append("  ")
+            .append(jar)
+            .append('\n');
+      }
     }
 
     builder.append('\n');


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
This changes the way expansions are sorted in the `/papi dump` command.

Previously did PlaceholderAPI sort the expansions by their Identifier and then by author.
Now it should sort them by identifier AND also by the author.

Idk... Nag @iGabyTM about this.

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
