### PR TITLE
fix(replacer): Stop lowercasing replacements

### DIFF
--- a/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
+++ b/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
@@ -106,7 +106,7 @@ public final class CharsReplacer implements Replacer {
 
       final PlaceholderExpansion placeholder = lookup.apply(lowercaseIdentifierString);
       if (placeholder == null) {
-        builder.append(closure.head).append(lowercaseIdentifierString);
+        builder.append(closure.head).append(identifierString);
 
         if (identified) {
           builder.append('_');
@@ -118,7 +118,7 @@ public final class CharsReplacer implements Replacer {
 
       final String replacement = placeholder.onRequest(player, parametersString);
       if (replacement == null) {
-        builder.append(closure.head).append(lowercaseIdentifierString);
+        builder.append(closure.head).append(identifierString);
 
         if (identified) {
           builder.append('_');


### PR DESCRIPTION
## Pull Request

### Type
- [ ] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
    This commit changes two lines but fixes the replacement of cased
    placeholders with non-cased ones that was accidentally happening.
    This was partially fixed in a few previous commits, but not fully as
    it was still replacing failed placeholder matches.

### Tests
Blitz has tested it and confirmed its correctness.
Before:
![Before](https://cdn.discordapp.com/attachments/574554521825705994/952286572592644176/unknown.png)
After:
![After](https://cdn.discordapp.com/attachments/574554521825705994/952289479232737350/unknown.png)

Closes #666 


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
