### PR TITLE
Add queue system for Expansion registration

### DIFF
--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
@@ -53,7 +53,6 @@ public final class PlaceholderAPIPlugin extends JavaPlugin {
   @NotNull
   private static final Version VERSION;
   private static PlaceholderAPIPlugin instance;
-  private boolean loaded = false;
 
   static {
     final String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
@@ -168,7 +167,6 @@ public final class PlaceholderAPIPlugin extends JavaPlugin {
     adventure = null;
 
     instance = null;
-    loaded = false;
   }
 
   public void reloadConf(@NotNull final CommandSender sender) {
@@ -214,10 +212,6 @@ public final class PlaceholderAPIPlugin extends JavaPlugin {
     return config;
   }
 
-  public boolean isLoaded() {
-    return loaded;
-  }
-
   private void setupCommand() {
     final PluginCommand pluginCommand = getCommand("placeholderapi");
     if (pluginCommand == null) {
@@ -251,7 +245,6 @@ public final class PlaceholderAPIPlugin extends JavaPlugin {
   private void setupExpansions() {
     Bukkit.getPluginManager().registerEvents(getLocalExpansionManager(), this);
 
-    this.loaded = true;
     try {
       Class.forName("org.bukkit.event.server.ServerLoadEvent");
       new ServerLoadEventListener(this);

--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
@@ -53,6 +53,7 @@ public final class PlaceholderAPIPlugin extends JavaPlugin {
   @NotNull
   private static final Version VERSION;
   private static PlaceholderAPIPlugin instance;
+  private boolean loaded = false;
 
   static {
     final String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
@@ -167,6 +168,7 @@ public final class PlaceholderAPIPlugin extends JavaPlugin {
     adventure = null;
 
     instance = null;
+    loaded = false;
   }
 
   public void reloadConf(@NotNull final CommandSender sender) {
@@ -212,6 +214,10 @@ public final class PlaceholderAPIPlugin extends JavaPlugin {
     return config;
   }
 
+  public boolean isLoaded() {
+    return loaded;
+  }
+
   private void setupCommand() {
     final PluginCommand pluginCommand = getCommand("placeholderapi");
     if (pluginCommand == null) {
@@ -245,6 +251,7 @@ public final class PlaceholderAPIPlugin extends JavaPlugin {
   private void setupExpansions() {
     Bukkit.getPluginManager().registerEvents(getLocalExpansionManager(), this);
 
+    this.loaded = true;
     try {
       Class.forName("org.bukkit.event.server.ServerLoadEvent");
       new ServerLoadEventListener(this);

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudUpdate.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudUpdate.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
@@ -48,12 +47,12 @@ public final class CommandECloudUpdate extends PlaceholderCommand {
     super("update");
   }
 
-  private static CompletableFuture<List<@Nullable Class<? extends PlaceholderExpansion>>> downloadAndDiscover(
+  private static CompletableFuture<List<@Nullable PlaceholderExpansion>> downloadAndDiscover(
       @NotNull final List<CloudExpansion> expansions, @NotNull final PlaceholderAPIPlugin plugin) {
     return expansions.stream()
         .map(expansion -> plugin.getCloudExpansionManager()
             .downloadExpansion(expansion, expansion.getVersion()))
-        .map(future -> future.thenCompose(plugin.getLocalExpansionManager()::findExpansionInFile))
+        .map(future -> future.thenCompose(plugin.getLocalExpansionManager()::findExpansion))
         .collect(Futures.collector());
   }
 
@@ -104,9 +103,7 @@ public final class CommandECloudUpdate extends PlaceholderCommand {
 
       final String message = classes.stream()
           .filter(Objects::nonNull)
-          .map(plugin.getLocalExpansionManager()::register)
-          .filter(Optional::isPresent)
-          .map(Optional::get)
+          .filter(plugin.getLocalExpansionManager()::addToQueue)
           .map(expansion -> "  &a" + expansion.getName() + " &f" + expansion.getVersion())
           .collect(Collectors.joining("\n"));
 

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandExpansionRegister.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandExpansionRegister.java
@@ -23,11 +23,9 @@ package me.clip.placeholderapi.commands.impl.local;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.logging.Level;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.commands.PlaceholderCommand;
-import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import me.clip.placeholderapi.expansion.manager.LocalExpansionManager;
 import me.clip.placeholderapi.util.Futures;
 import me.clip.placeholderapi.util.Msg;
@@ -60,31 +58,31 @@ public final class CommandExpansionRegister extends PlaceholderCommand {
       return;
     }
 
-    Futures.onMainThread(plugin, manager.findExpansionInFile(file), (clazz, exception) -> {
+    Futures.onMainThread(plugin, manager.findExpansion(file), (expansion, exception) -> {
       if (exception != null) {
         Msg.msg(sender,
-            "&cFailed to find expansion in file: &f" + file);
+            "&cFailed to find expansion in file: &f" + file.getName());
 
         plugin.getLogger()
-            .log(Level.WARNING, "failed to find expansion in file: " + file, exception);
+            .log(Level.WARNING, "failed to find expansion in file: " + file.getName(), exception);
         return;
       }
 
-      if (clazz == null) {
+      if (expansion == null) {
         Msg.msg(sender,
-            "&cNo expansion class found in file: &f" + file);
+            "&cNo expansion class found in file: &f" + file.getName());
         return;
       }
-
-      final Optional<PlaceholderExpansion> expansion = manager.register(clazz);
-      if (!expansion.isPresent()) {
+      
+      
+      if (!manager.addToQueue(expansion)) {
         Msg.msg(sender,
             "&cFailed to register expansion from &f" + params.get(0));
         return;
       }
 
       Msg.msg(sender,
-          "&aSuccessfully registered expansion: &f" + expansion.get().getName());
+          "&aSuccessfully registered expansion: &f" + expansion.getIdentifier());
 
     });
   }

--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandInfo.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandInfo.java
@@ -60,7 +60,7 @@ public final class CommandInfo extends PlaceholderCommand {
         .append(expansion.getName())
         .append('\n')
         .append("&7Status: &r")
-        .append(expansion.isRegistered() ? "&aRegistered" : "7cNotRegistered")
+        .append(expansion.isRegistered() ? "&aRegistered" : "&cNot Registered")
         .append('\n');
 
     final String author = expansion.getAuthor();

--- a/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
@@ -136,7 +136,7 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
    * @return true if this expansion is now registered with PlaceholderAPI
    */
   public boolean register() {
-    return getPlaceholderAPI().getLocalExpansionManager().register(this);
+    return getPlaceholderAPI().getLocalExpansionManager().addToQueue(this);
   }
 
   /**

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -89,7 +89,7 @@ public final class LocalExpansionManager implements Listener {
   private final Map<String, PlaceholderExpansion> expansions = new ConcurrentHashMap<>();
   private final ReentrantLock expansionsLock = new ReentrantLock();
   
-  private boolean loaded = false;
+  private boolean pluginLoaded = false;
 
   public LocalExpansionManager(@NotNull final PlaceholderAPIPlugin plugin) {
     this.plugin = plugin;
@@ -176,7 +176,7 @@ public final class LocalExpansionManager implements Listener {
       return false;
     }
     
-    if (loaded) {
+    if (pluginLoaded) {
       return loadExpansion(expansion);
     }
     
@@ -311,7 +311,7 @@ public final class LocalExpansionManager implements Listener {
 
   private void registerAll(@NotNull final CommandSender sender) {
     plugin.getLogger().info("Placeholder expansion registration initializing...");
-    loaded = true;
+    pluginLoaded = true;
     
     Futures.onMainThread(plugin, collectExpansions(), (expansions, exception) -> {
       if (exception != null) {
@@ -357,6 +357,7 @@ public final class LocalExpansionManager implements Listener {
 
       expansion.unregister();
     }
+    pluginLoaded = false;
   }
   
   @NotNull

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -170,42 +170,6 @@ public final class LocalExpansionManager implements Listener {
     return Optional.ofNullable(getExpansion(identifier));
   }
   
-  
-  public Optional<PlaceholderExpansion> register(
-      @NotNull final Class<? extends PlaceholderExpansion> clazz) {
-    try {
-      final PlaceholderExpansion expansion = createExpansionInstance(clazz);
-      
-      if(expansion == null){
-        return Optional.empty();
-      }
-      
-      Objects.requireNonNull(expansion.getAuthor(), "The expansion author is null!");
-      Objects.requireNonNull(expansion.getIdentifier(), "The expansion identifier is null!");
-      Objects.requireNonNull(expansion.getVersion(), "The expansion version is null!");
-
-      if (!expansion.register()) {
-        return Optional.empty();
-      }
-
-      return Optional.of(expansion);
-    } catch (LinkageError | NullPointerException ex) {
-      final String reason;
-
-      if (ex instanceof LinkageError) {
-        reason = " (Is a dependency missing?)";
-      } else {
-        reason = " - One of its properties is null which is not allowed!";
-      }
-
-      plugin.getLogger().severe("Failed to load expansion class " + clazz.getSimpleName() +
-              reason);
-      plugin.getLogger().log(Level.SEVERE, "", ex);
-    }
-
-    return Optional.empty();
-  }
-  
   @ApiStatus.Internal
   public boolean addToQueue(@NotNull final PlaceholderExpansion expansion) {
     if (!expansion.canRegister()) {
@@ -447,24 +411,6 @@ public final class LocalExpansionManager implements Listener {
   public CompletableFuture<@Nullable PlaceholderExpansion> findExpansion(@NotNull final File file) {
     return CompletableFuture.supplyAsync(() -> findExpansions(file));
   }
-
-
-  @Nullable
-  public PlaceholderExpansion createExpansionInstance(
-      @NotNull final Class<? extends PlaceholderExpansion> clazz) throws LinkageError {
-    try {
-      return clazz.getDeclaredConstructor().newInstance();
-    } catch (final Exception ex) {
-      if (ex.getCause() instanceof LinkageError) {
-        throw ((LinkageError) ex.getCause());
-      }
-
-      plugin.getLogger().warning("There was an issue with loading an expansion.");
-      
-      return null;
-    }
-  }
-
 
   @EventHandler
   public void onQuit(@NotNull final PlayerQuitEvent event) {

--- a/src/main/java/me/clip/placeholderapi/util/FileUtil.java
+++ b/src/main/java/me/clip/placeholderapi/util/FileUtil.java
@@ -50,7 +50,7 @@ public class FileUtil {
       JarEntry entry;
       while ((entry = stream.getNextJarEntry()) != null) {
         final String name = entry.getName();
-        if (name.isEmpty() || !name.endsWith(".class")) {
+        if (!name.endsWith(".class")) {
           continue;
         }
 


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

This is my attempt at creating a "queue" system for the expansion registration.

PlaceholderAPI right now has two distinct phases:

- Register expansions from plugins when their `register()` method is called
- Register expansions downloaded from the eCloud once server has completed its startup

This feels a bit weird and may even have weird results, if a plugin registers an expansion early on before anything else is loaded properly.
With this queue system, expansions should now be added to an internal queue and once the `registerAll()` method is called will PlaceholderAPI work its way through this queue.
Any future registration should then be registered directly.

I'll be honest here: Not the biggest fan of the way I implemented this, but I can't think of any better solutions, so please don't hesitate to suggest some alternative ways here.

From what I can see are there no breaking changes for the end-user as methods removed/changed where either declared private or annotated as Internal, so it would be their fault if stuff breaks for them.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
