### PR TITLE
Use GitHub's custom block quotes in repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,8 @@ body:
       
       Also, always make sure to use the latest Release from [Spigot](https://www.spigotmc.org/resources/6245/) or the latest Development Build from our [Jenkins Server](http://ci.extendedclip.com/job/PlaceholderAPI/) to make sure that your issue isn't already fixed.
       
-      **DO NOT REPORT ISSUES WITH EXPANSIONS AND/OR PLACEHOLDERS. USE THE APPROPRIATE ISSUE TRACKER FOR THOSE!**
+      > **Warning**  
+      > **DO NOT REPORT ISSUES WITH EXPANSIONS AND/OR PLACEHOLDERS. USE THE APPROPRIATE ISSUE TRACKER FOR THOSE!**
 - type: checkboxes
   attributes:
     label: Confirmation

--- a/wiki/Placeholders.md
+++ b/wiki/Placeholders.md
@@ -7,7 +7,7 @@ This is a list of all available placeholders.
 A download-command for the extension can be found at the area of the placeholder.  
 If the command itself isn't there and `NO DOWNLOAD COMMAND` instead is shown, then it means, that the plugin actually has the placeholders hard-coded into them and doesn't require a manual download of any expansion.
 
-> ## Notes (Please read)  
+> **Note**  
 > We only add and/or update placeholders on request.  
 > We aren't responsible, to keep the placeholders of your plugin(s) up to date.  
 > If anything about your expansion/plugin has changed, consider [making a Pull request](https://github.com/PlaceholderAPI/PlaceholderAPI/pulls) to commit the changes yourself.

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -78,6 +78,7 @@ These rules are as follows:
 - External links should be set as Refernce Links, which means they are set as `[text]: link` at the top of the page and then used either through `[text]` or `[display text][text]` througout the page.
 
 #### Adding new Expansion
+> **Note**  
 > We have a [Generator][placeholders_generator] that you can use for creating an entry in the Placeholders page.
 
 When you add a new expansion to the wiki's [Placeholder page][placeholders] will you need to follow the following format:  


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
GitHub added a new markdown feature where using a blockquote with `**Note**` or `**Warning**` as the first line renders it in color and with an SVG icon.

I'll leave this open for a while in case there are other wiki pages that benefit from it

Info: https://github.com/github/feedback/discussions/16925

Example:
```markdown
> **Note**  
> A cool note!
```

> **Note**  
> A cool note!

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
