### PR TITLE
Updated ThemePark, added ParkPlusMC to wiki

### DIFF
--- a/wiki/Placeholders.md
+++ b/wiki/Placeholders.md
@@ -3851,6 +3851,24 @@ Please see [this discussion][list] for a list of all expansions officially maint
 
 ----
 
+- ### **[ParkPlus](https://polymart.org/resource/parkplusmc.2317)**
+  > NO DOWNLOAD COMMAND
+  
+  ```
+  %pp_name:<AttractionID>%
+  %pp_status:<AttractionID>%
+  %pp_region:<AttractionID>%
+  %pp_ridecount%
+  %pp_ridecount:<AttractionID>%
+  %pp_ridecounttop_name:<AttractionID>:<Position>[:Type]%
+  %pp_ridecounttop_value:<AttractionID>:<Position>[:Type]%
+  ```
+  
+  Replace `<AttractionID>` with the ID of your attraction. Replace `<Position>` with the ridecount position.
+  Replace `[Type]` with the top type. Supported values: `DAILY, WEEKLY, MONTHLY, YEARLY, TOTAL`
+
+----
+
 - ### **[Parties](https://www.spigotmc.org/resources/3709/)**
   > NO DOWNLOAD COMMAND
   

--- a/wiki/Placeholders.md
+++ b/wiki/Placeholders.md
@@ -5419,9 +5419,12 @@ All placeholders are listed here: https://wiki.staffplusplus.org/integrations/pa
   %tp_region:<AttractionID>%
   %tp_ridecount%
   %tp_ridecount:<AttractionID>%
-  %tp_ridecounttop_name:<AttractionID>:<Position>%
-  %tp_ridecounttop_value:<AttractionID>:<Position>%
+  %tp_ridecounttop_name:<AttractionID>:<Position>[:Type]%
+  %tp_ridecounttop_value:<AttractionID>:<Position>[:Type]%
   ```
+  
+  Replace `<AttractionID>` with the ID of your attraction. Replace `<Position>` with the ridecount position.
+  Replace `[Type]` with the top type. Supported values: `DAILY, WEEKLY, MONTHLY, YEARLY, TOTAL`
 
 ----
 

--- a/wiki/Placeholders.md
+++ b/wiki/Placeholders.md
@@ -294,6 +294,7 @@ If the command itself isn't there and `NO DOWNLOAD COMMAND` instead is shown, th
   - ### **P**
     - **[Paintball Battle](#paintball-battle)**
     - **[Parkour](#parkour)**
+    - **[ParkPlusMC](#parkplusmc)**
     - **[Parties](#parties)**
     - **[Party and Friends](#party-and-friends)**
     - **[PermissionTimer](#permissiontimer)**
@@ -3851,7 +3852,7 @@ Please see [this discussion][list] for a list of all expansions officially maint
 
 ----
 
-- ### **[ParkPlus](https://polymart.org/resource/parkplusmc.2317)**
+- ### **[ParkPlusMC](https://polymart.org/resource/parkplusmc.2317)**
   > NO DOWNLOAD COMMAND
   
   ```

--- a/wiki/Plugins-using-PlaceholderAPI.md
+++ b/wiki/Plugins-using-PlaceholderAPI.md
@@ -611,6 +611,9 @@ If your plugin isn't shown here and you want it to be added, [open an issue](/Pl
 - **[Parkour](https://www.spigotmc.org/resources/23685/)**
   - [ ] Supports placeholders.
   - [x] Provides own placeholders. [**[[Link|Placeholders#parkour]]**]
+- **[ParkPlusMC](https://polymart.org/resource/parkplusmc.2317)**
+  - [ ] Supports placeholders.
+  - [x] Provides own placeholders. [**[[Link|Placeholders#parkplusmc]]**]
 - **[Parties](https://www.spigotmc.org/resources/3709/)**
   - [ ] Supports placeholders.
   - [x] Provides own placeholders. [**[[Link|Placeholders#parties]]**]


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
- Updated ThemePark placeholder information to v1.6.3
- Added ParkPlusMC placeholder information


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
