### PR TITLE
Fix for a strange error that didn't load expansions without `/papi reload`

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -378,7 +378,7 @@ public final class LocalExpansionManager implements Listener {
           Bukkit.getPluginManager().callEvent(new ExpansionsLoadedEvent(registered));
         });
       }
-    }.runTaskLater(plugin, 20L);
+    }.runTaskLater(plugin, 1L);
   }
 
   private void unregisterAll() {


### PR DESCRIPTION
## Pull Request

### Type
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
Fixes a strange error that didn't load expansions without `/papi reload`

[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
