### PR TITLE
Fix duplicate expansion loading

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/manager/CloudExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/CloudExpansionManager.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import me.clip.placeholderapi.expansion.cloud.CloudExpansion;
+import me.clip.placeholderapi.util.Msg;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
@@ -268,8 +269,7 @@ public final class CloudExpansionManager {
       await.remove(toIndexName(expansion));
 
       if (exception != null) {
-        plugin.getLogger().log(Level.SEVERE,
-            "failed to download " + expansion.getName() + ":" + version.getVersion(), exception);
+        Msg.severe("Failed to download %s:%s", exception, expansion.getName(), expansion.getVersion());
       }
     }, ASYNC_EXECUTOR);
 

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -218,7 +218,7 @@ public final class LocalExpansionManager implements Listener {
     }
     
     if (expansions.containsKey(identifier)) {
-      Msg.warn("Failed to load expansion %s. Identifier is already registered.",
+      Msg.warn("Failed to load expansion %s. Identifier is already in use.",
           expansion.getIdentifier());
       return false;
     }

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -216,6 +216,12 @@ public final class LocalExpansionManager implements Listener {
     if (!expansion.canRegister()) {
       return false;
     }
+    
+    if (expansions.containsKey(identifier)) {
+      Msg.warn("Failed to load expansion %s. Identifier is already registered.",
+          expansion.getIdentifier());
+      return false;
+    }
 
     if (expansion instanceof Configurable) {
       Map<String, Object> defaults = ((Configurable) expansion).getDefaults();
@@ -388,7 +394,7 @@ public final class LocalExpansionManager implements Listener {
   @NotNull
   public CompletableFuture<@NotNull List<@Nullable Class<? extends PlaceholderExpansion>>> findExpansionsOnDisk() {
     File[] files = folder.listFiles((dir, name) -> name.endsWith(".jar"));
-    if(files == null){
+    if (files == null) {
       return CompletableFuture.completedFuture(Collections.emptyList());
     }
     


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes #864 

Fixes an issue where the same expansion would be loaded twice, if the jar file used has a slightly different name.

Now PlaceholderAPI checks if the used identifier is already registered and in such a case prints a warning and doesn't load the expansion.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
