### PR TITLE
Fix inconsistent parsing command behaviour

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandParse.java
@@ -30,7 +30,6 @@ import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.commands.PlaceholderCommand;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import me.clip.placeholderapi.util.Msg;
-import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
@@ -123,13 +122,9 @@ public final class CommandParse extends PlaceholderCommand {
     }
 
     if (broadcast) {
-      Msg.broadcast(message);
+      Bukkit.broadcastMessage(message);
     } else {
-      if (!(sender instanceof Player)) {
-        Msg.msg(sender, message);
-      } else {
-        ((Player) sender).spigot().sendMessage(TextComponent.fromLegacyText(message));
-      }
+      sender.sendMessage(message);
     }
   }
 
@@ -156,7 +151,8 @@ public final class CommandParse extends PlaceholderCommand {
     final String message = PlaceholderAPI
         .setRelationalPlaceholders(((Player) targetOne), ((Player) targetTwo),
             String.join(" ", params.subList(2, params.size())));
-    Msg.msg(sender, message);
+    
+    sender.sendMessage(message);
   }
 
 


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes #872

Makes the parsing command more consistent by simply not parsing colors and sending the results either through `CommandSender#sendMessage(String)` or `Bukkit.broadcastMessage(String)`

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
