### PR TITLE
Add space to message

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudStatus.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudStatus.java
@@ -54,7 +54,7 @@ public final class CommandECloudStatus extends PlaceholderCommand {
 
     if (updateCount > 0) {
       builder.append("&eYou have &f").append(updateCount)
-          .append(updateCount > 1 ? "&e expansions" : "&e expansion").append("installed that ")
+          .append(updateCount > 1 ? "&e expansions" : "&e expansion").append(" installed that ")
           .append(updateCount > 1 ? "have an" : "has an").append(" update available.");
     }
 


### PR DESCRIPTION
## Pull Request

### Type
- [ ] Internal change (Doesn't affect end-user).
- [X] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: 

### Description
Add a missing space to the ecloud status message shown in the following picture.
![image](https://user-images.githubusercontent.com/86119630/209481421-2f6803ba-db80-4f82-acb9-6022c6db2be8.png)


Closes N/A

[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
