### PR TITLE
Since .persist() is to indicate that the expansion is not provided th…

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/manager/CloudExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/CloudExpansionManager.java
@@ -220,7 +220,7 @@ public final class CloudExpansionManager {
                             plugin.getLocalExpansionManager().findExpansionByName(name);
                         if (localOpt.isPresent()) {
                           PlaceholderExpansion local = localOpt.get();
-                          if (local.isRegistered()) {
+                          if (local.isRegistered() && !local.persist()) {
                             expansion.setHasExpansion(true);
                             expansion.setShouldUpdate(
                                 !local.getVersion().equalsIgnoreCase(expansion.getLatestVersion()));


### PR DESCRIPTION
…rough eCloud but through a plugin, if this is true, there is no need to check against eCloud entries.

<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Since .persist() is to indicate that the expansion is not provided through eCloud but through a plugin, if this is true, there is no need to check against eCloud entries.


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
