### PR TITLE
Make setPlaceholders behavior consistent with setRelationalPlaceholders

### DIFF
--- a/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
+++ b/src/main/java/me/clip/placeholderapi/replacer/CharsReplacer.java
@@ -67,8 +67,12 @@ public final class CharsReplacer implements Replacer {
           hadSpace = true;
           break;
         }
-        if (p == closure.tail) {
+        if (p == closure.tail && identified) {
           invalid = false;
+          break;
+        }
+        if (p == closure.tail) {
+          identifier.append(p);
           break;
         }
 


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
Relational placeholders require an underscore after the identifier to be considered valid. For example: `%rel_chatchat_%` is valid but `%rel_chatchat%` is not. Normal placeholders did not require this and `%chatchat%` worked the same as `%chatchat_%`.

This can be considered a breaking change but it breaks what I consider to be a bug. 😄
Image of usage after the change:
![image](https://user-images.githubusercontent.com/52609756/227620894-7cda5b2b-df61-40f5-bc9a-14e44c918878.png)

Closes #941  <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
