### PR TITLE
Prevent loading of extensions outside of the expansions folder using the register command

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandExpansionRegister.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/local/CommandExpansionRegister.java
@@ -54,7 +54,7 @@ public final class CommandExpansionRegister extends PlaceholderCommand {
     final LocalExpansionManager manager = plugin.getLocalExpansionManager();
 
     final File file = new File(manager.getExpansionsFolder(), params.get(0));
-    if (!file.exists()) {
+    if (!file.exists() || !file.getParentFile().equals(manager.getExpansionsFolder())) {
       Msg.msg(sender,
           "&cThe file &f" + file.getName() + "&c doesn't exist!");
       return;


### PR DESCRIPTION
## Pull Request

### Type
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
This pull request prevents loading expansions from folders other than the expansions folder.
In previous versions, you could use path traversal with `../` to load expansions from other directories, e.g. `/papi register ../../../world/expansion.jar` would load an expansion from the world folder.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
