### PR TITLE
Add environment variable to block individual ecloud expansions.

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudDownload.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudDownload.java
@@ -20,6 +20,7 @@
 
 package me.clip.placeholderapi.commands.impl.cloud;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -37,6 +38,16 @@ public final class CommandECloudDownload extends PlaceholderCommand {
     super("download");
   }
 
+  private boolean isBlockedExpansion(String name) {
+    String env = System.getenv("PAPI_BLOCKED_EXPANSIONS");
+    if (env == null) {
+      return false;
+    }
+
+    return Arrays.stream(env.split(","))
+            .anyMatch(s -> s.equalsIgnoreCase(name));
+  }
+
   @Override
   public void evaluate(@NotNull final PlaceholderAPIPlugin plugin,
       @NotNull final CommandSender sender, @NotNull final String alias,
@@ -44,6 +55,12 @@ public final class CommandECloudDownload extends PlaceholderCommand {
     if (params.isEmpty()) {
       Msg.msg(sender,
           "&cYou must supply the name of an expansion.");
+      return;
+    }
+
+    if (isBlockedExpansion(params.get(0))) {
+      Msg.msg(sender,
+          "&cThis expansion can't be downloaded.");
       return;
     }
 


### PR DESCRIPTION
## Pull Request

### Type
- [ ] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
This commit adds the environment variable "PAPI_BLOCKED_EXPANSIONS" which can contain a case-insensitive, comma separated list of blocked expansions. Expansions on this list can no longer be downloaded using commands.
By default, all extensions will remain downloadable.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
