### PR TITLE
feat: distinguish expansions (external or internal) (fixes #945)

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
@@ -136,7 +136,7 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
    * @return true if this expansion is now registered with PlaceholderAPI
    */
   public boolean register() {
-    return getPlaceholderAPI().getLocalExpansionManager().register(this);
+    return getPlaceholderAPI().getLocalExpansionManager().register(this, false);
   }
 
   /**

--- a/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
@@ -41,6 +41,14 @@ import org.jetbrains.annotations.Nullable;
 public abstract class PlaceholderExpansion extends PlaceholderHook {
 
   /**
+   * The type is {@link Type#INTERNAL} by default.
+   * For external expansions, the type is updated on {@link me.clip.placeholderapi.expansion.manager.LocalExpansionManager#register(Class) register}.
+   * @since 2.11.4
+   */
+  @ApiStatus.Internal
+  protected Type expansionType = Type.INTERNAL;
+
+  /**
    * The placeholder identifier of this expansion. May not contain {@literal %},
    * {@literal {}} or _
    *
@@ -136,7 +144,7 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
    * @return true if this expansion is now registered with PlaceholderAPI
    */
   public boolean register() {
-    return getPlaceholderAPI().getLocalExpansionManager().register(this, false);
+    return getPlaceholderAPI().getLocalExpansionManager().register(this);
   }
 
   /**
@@ -159,6 +167,27 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
     return PlaceholderAPIPlugin.getInstance();
   }
 
+  /**
+   * Get the type of the expansion
+   *
+   * @return the type of the expansion
+   * @since 2.11.4
+   */
+  @ApiStatus.Internal
+  public Type getExpansionType() {
+    return expansionType;
+  }
+
+  /**
+   * Set the type of the expansion
+   * @param expansionType the new type
+   * @since 2.11.4
+   */
+  @ApiStatus.Internal
+  public void setExpansionType(Type expansionType) {
+    this.expansionType = expansionType;
+  }
+
   // === Configuration ===
   
   /**
@@ -166,7 +195,7 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
    * null when not specified.
    * <br>You may use the {@link Configurable} interface to define default values set
    * 
-   * @return ConfigurationSection that this epxpansion has.
+   * @return ConfigurationSection that this expansion has.
    */
   @Nullable
   public final ConfigurationSection getConfigSection() {
@@ -394,8 +423,8 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
    */
   @Override
   public final String toString() {
-    return String.format("PlaceholderExpansion[name: '%s', author: '%s', version: '%s']", getName(),
-        getAuthor(), getVersion());
+    return String.format("PlaceholderExpansion[name: '%s', author: '%s', version: '%s', type: '%s']", getName(),
+        getAuthor(), getVersion(), getExpansionType());
   }
 
   // === Deprecated API ===
@@ -432,4 +461,19 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
   public String getLink() {
     return null;
   }
+
+  public enum Type {
+
+    /**
+     * An expansion provided by a plugin is considered internal
+     */
+    INTERNAL,
+
+    /**
+     * An expansion loaded from the expansions folder is considered external
+     */
+    EXTERNAL
+
+  }
+
 }

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -294,21 +294,24 @@ public final class LocalExpansionManager implements Listener {
       Bukkit.getPluginManager().registerEvents(((Listener) expansion), plugin);
     }
     
-    Msg.info("Successfully registered expansion: %s [%s]", expansion.getIdentifier(),
-        expansion.getVersion());
+    Msg.info(
+            "Successfully registered %s expansion: %s [%s]",
+            expansion.getExpansionType().name().toLowerCase(),
+            expansion.getIdentifier(),
+            expansion.getVersion()
+    );
 
     if (expansion instanceof Taskable) {
       ((Taskable) expansion).start();
     }
 
-    if (plugin.getPlaceholderAPIConfig().isCloudEnabled()) {
-      final Optional<CloudExpansion> cloudExpansionOptional =
-          plugin.getCloudExpansionManager().findCloudExpansionByName(identifier);
+    // Check eCloud for updates only if the expansion is external
+    if (plugin.getPlaceholderAPIConfig().isCloudEnabled() && expansion.getExpansionType() == PlaceholderExpansion.Type.EXTERNAL) {
+      final Optional<CloudExpansion> cloudExpansionOptional = plugin.getCloudExpansionManager().findCloudExpansionByName(identifier);
       if (cloudExpansionOptional.isPresent()) {
         CloudExpansion cloudExpansion = cloudExpansionOptional.get();
         cloudExpansion.setHasExpansion(true);
-        cloudExpansion.setShouldUpdate(
-            !cloudExpansion.getLatestVersion().equals(expansion.getVersion()));
+        cloudExpansion.setShouldUpdate(!cloudExpansion.getLatestVersion().equals(expansion.getVersion()));
       }
     }
 

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -209,15 +209,22 @@ public final class LocalExpansionManager implements Listener {
     return Optional.empty();
   }
 
+  /**
+   * Attempt to register a {@link PlaceholderExpansion}
+   * @param expansion the expansion to register
+   * @param isExternalExpansion whether the expansion is external (loaded from the {@link LocalExpansionManager#EXPANSIONS_FOLDER_NAME expansions folder})
+   * @return if the expansion was registered
+   */
   @ApiStatus.Internal
-  public boolean register(@NotNull final PlaceholderExpansion expansion) {
+  public boolean register(@NotNull final PlaceholderExpansion expansion, final boolean isExternalExpansion) {
     final String identifier = expansion.getIdentifier().toLowerCase(Locale.ROOT);
 
     if (!expansion.canRegister()) {
       return false;
     }
-    
-    if (expansions.containsKey(identifier)) {
+
+    // Avoid loading two external expansions with the same identifier
+    if (isExternalExpansion && expansions.containsKey(identifier)) {
       Msg.warn("Failed to load expansion %s. Identifier is already in use.",
           expansion.getIdentifier());
       return false;
@@ -306,6 +313,17 @@ public final class LocalExpansionManager implements Listener {
     }
 
     return true;
+  }
+
+  /**
+   * Overload for {@link #register(PlaceholderExpansion, boolean)} to provide backwards compatibility for expansions / plugins
+   * that call this method directly. It is the equivalent of {@code register(expansion, false)}
+   * @param expansion the expansion to register
+   * @return if the expansion was registered
+   */
+  @ApiStatus.Internal
+  public boolean register(@NotNull final PlaceholderExpansion expansion) {
+    return register(expansion, false);
   }
 
   @ApiStatus.Internal

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -187,6 +187,8 @@ public final class LocalExpansionManager implements Listener {
           return Optional.empty();
         }
       }
+
+      expansion.setExpansionType(PlaceholderExpansion.Type.EXTERNAL);
       
       if (!expansion.register()) {
         Msg.warn("Cannot load expansion %s due to an unknown issue.", expansion.getIdentifier());
@@ -212,11 +214,10 @@ public final class LocalExpansionManager implements Listener {
   /**
    * Attempt to register a {@link PlaceholderExpansion}
    * @param expansion the expansion to register
-   * @param isExternalExpansion whether the expansion is external (loaded from the {@link LocalExpansionManager#EXPANSIONS_FOLDER_NAME expansions folder})
    * @return if the expansion was registered
    */
   @ApiStatus.Internal
-  public boolean register(@NotNull final PlaceholderExpansion expansion, final boolean isExternalExpansion) {
+  public boolean register(@NotNull final PlaceholderExpansion expansion) {
     final String identifier = expansion.getIdentifier().toLowerCase(Locale.ROOT);
 
     if (!expansion.canRegister()) {
@@ -224,9 +225,8 @@ public final class LocalExpansionManager implements Listener {
     }
 
     // Avoid loading two external expansions with the same identifier
-    if (isExternalExpansion && expansions.containsKey(identifier)) {
-      Msg.warn("Failed to load expansion %s. Identifier is already in use.",
-          expansion.getIdentifier());
+    if (expansion.getExpansionType() == PlaceholderExpansion.Type.EXTERNAL && expansions.containsKey(identifier)) {
+      Msg.warn("Failed to load external expansion %s. Identifier is already in use.", expansion.getIdentifier());
       return false;
     }
 
@@ -313,19 +313,6 @@ public final class LocalExpansionManager implements Listener {
     }
 
     return true;
-  }
-
-  /**
-   * Overload for {@link #register(PlaceholderExpansion, boolean)} to provide backwards compatibility for expansions / plugins
-   * that call this method directly. It is the equivalent of {@code register(expansion, false)}
-   * @param expansion the expansion to register
-   * @return if the expansion was registered
-   * @deprecated use {@link #register(PlaceholderExpansion, boolean)} directly
-   */
-  @Deprecated
-  @ApiStatus.Internal
-  public boolean register(@NotNull final PlaceholderExpansion expansion) {
-    return register(expansion, false);
   }
 
   @ApiStatus.Internal

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -320,7 +320,9 @@ public final class LocalExpansionManager implements Listener {
    * that call this method directly. It is the equivalent of {@code register(expansion, false)}
    * @param expansion the expansion to register
    * @return if the expansion was registered
+   * @deprecated use {@link #register(PlaceholderExpansion, boolean)} directly
    */
+  @Deprecated
   @ApiStatus.Internal
   public boolean register(@NotNull final PlaceholderExpansion expansion) {
     return register(expansion, false);


### PR DESCRIPTION
external: located in the `expansions` folder
internal: registered by a plugin

<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
