### PR TITLE
Add note about blocking specific ecloud expansions using environment

### DIFF
--- a/Expansion-cloud.md
+++ b/Expansion-cloud.md
@@ -25,7 +25,9 @@ Your expansion is now uploaded and will be reviewed by a moderator.
 If everything is ok will your expansion be approved and will be available on the ecloud for PlaceholderAPI*.
 
 > *You can only download verified Expansions through PlaceholderAPIs command, unless you enable the option `cloud_allow_unverified_expansions` in the config.yml  
-> Unverified expansions can be downloaded manually by going to the site and download it yourself.
+> Unverified expansions can be downloaded manually by going to the site and download it yourself.  
+> You can block specific expansions from being downloaded using the `PAPI_BLOCKED_EXPANSIONS` environment variable.
+> It contains a comma separated list of expansion names, that should be blocked from being downloaded.
 
 ## Updating your expansion
 Before you update, please note the following:  


### PR DESCRIPTION
## Pull Request

### Type
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
This PR mentions the new PAPI_BLOCKED_EXPANSIONS environment variable as added in [#947](https://github.com/PlaceholderAPI/PlaceholderAPI/pull/947)

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
