### PR TITLE
Add environment variable to override cloud_allowunverified_expansions

### DIFF
--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudDownload.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudDownload.java
@@ -51,16 +51,7 @@ public final class CommandECloudDownload extends PlaceholderCommand {
   private boolean areUnverifiedExpansionsAllowed(@NotNull final PlaceholderAPIPlugin plugin) {
     String env = System.getenv("PAPI_ALLOW_UNVERIFIED_EXPANSIONS");
     if (env != null) {
-      switch (env.toLowerCase()) {
-        case "true":
-        case "yes":
-        case "1":
-          return true;
-        case "false":
-        case "no":
-        case "0":
-          return false;
-      }
+      return env.equalsIgnoreCase("true");
     }
 
     return plugin.getPlaceholderAPIConfig().cloudAllowUnverifiedExpansions();

--- a/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudDownload.java
+++ b/src/main/java/me/clip/placeholderapi/commands/impl/cloud/CommandECloudDownload.java
@@ -48,6 +48,24 @@ public final class CommandECloudDownload extends PlaceholderCommand {
             .anyMatch(s -> s.equalsIgnoreCase(name));
   }
 
+  private boolean areUnverifiedExpansionsAllowed(@NotNull final PlaceholderAPIPlugin plugin) {
+    String env = System.getenv("PAPI_ALLOW_UNVERIFIED_EXPANSIONS");
+    if (env != null) {
+      switch (env.toLowerCase()) {
+        case "true":
+        case "yes":
+        case "1":
+          return true;
+        case "false":
+        case "no":
+        case "0":
+          return false;
+      }
+    }
+
+    return plugin.getPlaceholderAPIConfig().cloudAllowUnverifiedExpansions();
+  }
+
   @Override
   public void evaluate(@NotNull final PlaceholderAPIPlugin plugin,
       @NotNull final CommandSender sender, @NotNull final String alias,
@@ -72,7 +90,7 @@ public final class CommandECloudDownload extends PlaceholderCommand {
       return;
     }
 
-    if (!expansion.isVerified() && !plugin.getPlaceholderAPIConfig().cloudAllowUnverifiedExpansions()) {
+    if (!expansion.isVerified() && !this.areUnverifiedExpansionsAllowed(plugin)) {
       Msg.msg(sender, "&cThe expansion '&f" + params.get(0) + "&c' is not verified and can only be downloaded manually from &fhttps://placeholderapi.com/ecloud");
       return;
     }


### PR DESCRIPTION
## Pull Request

### Type
- [ ] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
This pull request adds the environment variable PAPI_ALLOW_UNVERIFIED_EXPANSIONS.
It allows overriding the option set in the config.yml.

~~Accepted values are (case-insensitive) `true`, `yes` and `1` to allow expansions or `false`, `no` and `0` to forbid them.
If the environment variable is not set or the value is not valid, the value specified in the config.yml will be used.~~

If the value is set to `true` unverified expansions will be allowed (case-insensitive), if it is set to any other value, unverified expansions will be forbidden.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
