### PR TITLE
Added missing NotNull annotations to setBracketPlaceholders methods

### DIFF
--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPI.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPI.java
@@ -136,8 +136,8 @@ public final class PlaceholderAPI {
    * @return String containing all translated placeholders
    */
   @NotNull
-  public static List<String> setBracketPlaceholders(final OfflinePlayer player,
-      @NotNull final List<String> text) {
+  public static List<@NotNull String> setBracketPlaceholders(final OfflinePlayer player,
+      @NotNull final List<@NotNull String> text) {
     return text.stream().map(line -> setBracketPlaceholders(player, line))
         .collect(Collectors.toList());
   }

--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPI.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPI.java
@@ -150,7 +150,8 @@ public final class PlaceholderAPI {
    * @param text Text to set the placeholder values in
    * @return String containing all translated placeholders
    */
-  public static String setBracketPlaceholders(Player player, String text) {
+  @NotNull
+  public static String setBracketPlaceholders(Player player, @NotNull String text) {
     return setBracketPlaceholders((OfflinePlayer) player, text);
   }
   

--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPI.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPI.java
@@ -162,7 +162,8 @@ public final class PlaceholderAPI {
    * @param text List of Strings to set the placeholder values in
    * @return String containing all translated placeholders
    */
-  public static List<String> setBracketPlaceholders(Player player, List<String> text) {
+  @NotNull
+  public static List<String> setBracketPlaceholders(Player player, @NotNull List<String> text) {
     return setBracketPlaceholders((OfflinePlayer) player, text);
   }
 


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [X] Internal change (Doesn't affect end-user).
- [X] External change (Does affect end-user).
- [X] Other: Added missing annotations, so it kinda does, but also does not really affect API users

### Description
<!-- What does your Pull request change? -->

This adds missing NotNull annotations to three setBracketPlaceholders methods. As they all internally just call methods which already are annotated with NotNull for both the return value and the parameters, it's safe to add the annotations to these methods too.

(In fact I was kinda surprised when those annotations were missing, so I looked at the source to confirm the annotations are just missing instead of being absent on purpose)


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
