### PR TITLE
Add Hangar and BuiltByBit pages to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ If you would like to create your own Placeholder Expansion for PlaceholderAPI, t
 - [Placeholder List]
 - [Spigot Page][spigot]
 - [Hangar Page][hangar]
-- [BuildByBit Page][bbb]
+- [BuiltByBit Page][bbb]
 - [Plugin Statistics][statistics]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 [discord]: https://helpch.at/discord
 [spigot]: https://www.spigotmc.org/resources/6245/
+[hangar]: https://hangar.papermc.io/HelpChat/PlaceholderAPI
+[bbb]: https://builtbybit.com/resources/placeholderapi.24306
 [Expansions cloud]: https://api.extendedclip.com/home
 [placeholder list]: https://helpch.at/placeholders
 [statistics]: https://bstats.org/plugin/bukkit/PlaceholderAPI
@@ -47,4 +49,6 @@ If you would like to create your own Placeholder Expansion for PlaceholderAPI, t
 - [Expansions Cloud]
 - [Placeholder List]
 - [Spigot Page][spigot]
+- [Hangar Page][hangar]
+- [Build By Bit][bbb]
 - [Plugin Statistics][statistics]

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ If you would like to create your own Placeholder Expansion for PlaceholderAPI, t
 - [Placeholder List]
 - [Spigot Page][spigot]
 - [Hangar Page][hangar]
-- [Build By Bit][bbb]
+- [BuildByBit Page][bbb]
 - [Plugin Statistics][statistics]


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [x] Other: Updating README.md <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

PlaceholderAPI is also available on Hangar (Paper's own plugins sharing platform) and BuiltByBit (formerly mc-market).
This PR adds those links to the readme to allow them to be found more easily. Maybe a announcement in the discussions tab should be made too to inform about the other platforms you can find PAPI on?

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
