### PR TITLE
[Wiki] Remove incorrect "optional" word

### DIFF
--- a/Hook-into-PlaceholderAPI.md
+++ b/Hook-into-PlaceholderAPI.md
@@ -94,7 +94,7 @@ Next step is to go to your plugin.yml or paper-plugin.yml and add PlaceholderAPI
   author: author
   main: your.main.path.Here
   
-  # This sets PlaceholderAPI as an optional dependency for your plugin.
+  # This sets PlaceholderAPI as a dependency for your plugin.
   depend: [PlaceholderAPI]
   ```
 - `paper-plugin.yml`


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

This commit removes the incorrect word "optional" in _depend_ comment. Before this commit, both _softdepend_ and _depend_ had the same "optional" comment of.

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://github.com/PlaceholderAPI/PlaceholderAPI/wiki
