### PR TITLE
Use the OfflinePlayer$getPlayer method instead of casting to Player class

### DIFF
--- a/src/main/java/me/clip/placeholderapi/PlaceholderHook.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderHook.java
@@ -29,7 +29,7 @@ public abstract class PlaceholderHook {
   @Nullable
   public String onRequest(final OfflinePlayer player, @NotNull final String params) {
     if (player != null && player.isOnline()) {
-      return onPlaceholderRequest((Player) player, params);
+      return onPlaceholderRequest(player.getPlayer(), params);
     }
 
     return onPlaceholderRequest(null, params);


### PR DESCRIPTION
## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description

Uses the OfflinePlayer$getPlayer method instead of casting to the Player class. That avoids a class cast exception if other plugins uses an own implementation of the offline player class. 


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
