### PR TITLE
Add 1.20.2 - 1.20.5 to NMSVersion.java

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/NMSVersion.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/NMSVersion.java
@@ -47,7 +47,10 @@ public enum NMSVersion {
   SPIGOT_1_19_R1("v1_19_R1"),
   SPIGOT_1_19_R2("v1_19_R2"),
   SPIGOT_1_19_R3("v1_19_R3"),
-  SPIGOT_1_20_R1("v1_20_R1");
+  SPIGOT_1_20_R1("v1_20_R1"),
+  SPIGOT_1_20_R2("v1_20_R2"),
+  SPIGOT_1_20_R3("v1_20_R3"),
+  SPIGOT_1_20_R4("v1_20_R4");
 
   private final String version;
 


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [x] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->

Adds the missing `1.20.x` versions, which there are apparently a lot of missing. This also includes 1.20.5.

The NMS versions were taken using MiniDigger's Spigot-resolver.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
