### PR TITLE
Use ExpansionType check for persistence

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/PlaceholderExpansion.java
@@ -110,7 +110,12 @@ public abstract class PlaceholderExpansion extends PlaceholderHook {
    * command is used
    *
    * @return if this expansion should persist through placeholder reloads
+   * 
+   * @deprecated PlaceholderExpansions registered through their {@link #register()} and not through
+   *             {@link me.clip.placeholderapi.expansion.manager.LocalExpansionManager#register(Class)}
+   *             will be considered internal now and not be unregistered during Plugin reloads.
    */
+  @Deprecated
   public boolean persist() {
     return false;
   }


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [s] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes N/A <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->

PlaceholderAPI is still solely relying on the `persist()` boolean method to check if an expansion should be unregistered or not.
And as prooven by #1070 is this a faulty aproach, as a dev missing the override or not setting it to return true can cause an internal expansion to unregister and not register again due to it being internal.

Since we now have an Enum to set an expansion's type to be either Internal (Default) or external, is there no need for this extra method to be needed, hence why this PR deprecates it and updates the expansion manager to check not only for `persist()` being true, but also for when it is marked internal.

This also adds a warning for the case where an expansion is marked external, but has `persist()` return true, which it should never be.
<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
