### PR TITLE
included IncompatibleClassChangeError to handle classes, which are in…

### DIFF
--- a/src/main/java/me/clip/placeholderapi/util/FileUtil.java
+++ b/src/main/java/me/clip/placeholderapi/util/FileUtil.java
@@ -63,7 +63,7 @@ public class FileUtil {
           if (clazz.isAssignableFrom(loaded)) {
             classes.add(loaded.asSubclass(clazz));
           }
-        } catch (final NoClassDefFoundError ignored) {
+        } catch (final NoClassDefFoundError | IncompatibleClassChangeError ignored) {
         }
       }
     }


### PR DESCRIPTION
…cluded in a jar to provide backward compatibility.

<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
This request catches IncompatibleClassChangeError during the loading of the .class file from the expansion .jar file.  Some .jar files may include .class files which are designed to provide backward compatibilities.  Such classes to support older Minecraft versions might throw IncompatibleClassChangeError during the loading of .class file but they can be safely ignored.
 <!-- If your PR is based on an issue, change "N/A" the the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
