### PR TITLE
Fix typo in placeholder expansion documentation

### DIFF
--- a/docs/developers/creating-a-placeholderexpansion.md
+++ b/docs/developers/creating-a-placeholderexpansion.md
@@ -93,7 +93,7 @@ public class SomeExpansion extends PlaceholderExpansion {
 4.  Called by PlaceholderAPI to have placeholder values parsed.  
     When not overriden will call `onPlaceholderRequest(Player, String)`, converting the OfflinePlayer to a Player if possible or else providing `null`.
     
-    Using this method is recommended for the usage of the OfflinePlayer, allowing to use data from a player without their precense being required.
+    Using this method is recommended for the usage of the OfflinePlayer, allowing to use data from a player without their presence being required.
     
     **Parameters**:
     


### PR DESCRIPTION
Corrected a typographical error in the documentation regarding the usage of OfflinePlayer.

<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes N/A <!-- If your PR is based on an issue, change "N/A" to the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
