### PR TITLE
Remove FunnyGuilds placeholders from wiki

### DIFF
--- a/docs/users/placeholder-list.md
+++ b/docs/users/placeholder-list.md
@@ -227,7 +227,6 @@ Further details on how to contribute to this list or the wiki as a whole can be 
         - **[Factions MCore](#factions-mcore)**
         - **[FactionsUUID](#factionsuuid)**
         - **[Factions relation placeholders](#factions-relation-placeholders)**
-        - **[FunnyGuilds](#funnyguilds)**
     
     - **G**
         - **[GAListener](#galistener)**
@@ -3167,42 +3166,6 @@ You can find an up-to-date list of placeholders on the [FactionsUUID Wiki](https
 /// note  
 These placeholders work with FactionsUUID and MCore all you need is downloading the expansion of the plugin you're using. if you're using these placeholders in DeluxeChat you need to enable this option "relation_placeholders_enabled: true" you can find that in the config.
 ///
-
-----
-
-### **[FunnyGuilds](https://github.com/FunnyGuilds/FunnyGuilds)**
-/// integrated | Built into Plugin
-///
-
-```
-%funnyguilds_guilds%
-%funnyguilds_users%
-%funnyguilds_deaths%
-%funnyguilds_kdr%
-%funnyguilds_kills%
-%funnyguilds_points-format%
-%funnyguilds_points%
-%funnyguilds_position%
-%funnyguilds_g-allies%
-%funnyguilds_g-deaths%
-%funnyguilds_g-deputies%
-%funnyguilds_g-deputy%
-%funnyguilds_g-kdr%
-%funnyguilds_g-kills%
-%funnyguilds_g-lives%
-%funnyguilds_g-members-all%
-%funnyguilds_g-members-online%
-%funnyguilds_g-name%
-%funnyguilds_g-owner%
-%funnyguilds_g-points-format%
-%funnyguilds_g-points%
-%funnyguilds_g-position%
-%funnyguilds_g-region-size%
-%funnyguilds_g-tag%
-%funnyguilds_g-validity%
-%funnyguilds_gtop-x%
-%funnyguilds_ptop-x%
-```
 
 ----
 

--- a/docs/users/plugins-using-placeholderapi.md
+++ b/docs/users/plugins-using-placeholderapi.md
@@ -389,9 +389,6 @@ If your plugin isn't shown here and you want it to be added, [read the Wiki READ
 - **[FactionsUUID](https://www.spigotmc.org/resources/1035/)**
     - [x] Supports placeholders.
     - [x] Provides own placeholders. [**[Link](placeholder-list.md#factionsuuid)**]
-- **[FunnyGuilds](https://github.com/FunnyGuilds/FunnyGuilds)**
-    - [ ] Supports placeholders.
-    - [x] Provides own placeholders. [**[Link](placeholder-list.md#funnyguilds)**]
 - **[FriendReferral](https://www.spigotmc.org/resources/21626/)**
     - [x] Supports placeholders.
     - [ ] Provides own placeholders. [Link]


### PR DESCRIPTION
## Pull Request

### Type

- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description

Hi, I'm one of the maintainers of [FunnyGuilds](https://github.com/FunnyGuilds/FunnyGuilds). We're currently in the middle of some bigger rewrites, some of them touch the placeholders the plugin adds. For the time being we have our own wiki as the main source of truth, so until all the changes are finalized - we wan't to remove the placeholder list from PlaceholderAPI wiki and just keep [our list](https://github.com/FunnyGuilds/FunnyGuilds/wiki/%5BEN%5D-PlaceholderAPI). It will be less confusing for our users.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
