### PR TITLE
Add Pull request validation for Wiki

### DIFF
--- a/.github/workflows/validate_site.yml
+++ b/.github/workflows/validate_site.yml
@@ -1,0 +1,53 @@
+name: "Validate Wiki Build"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths-ignore:
+      - "README.md"
+    branches:
+      - wiki
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_number }}"
+
+jobs:
+  buildWiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: "${{ github.event.pull_request.head.sha }}"
+      - name: "Setup Python 3.x"
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - name: "Install dependencies"
+        run: "pip install -r requirements.txt"
+      - name: "Build Site"
+        run: "mkdocs build --strict"
+  commentOnFail:
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    steps:
+      - name: "Create Comment"
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          body: |-
+            ## Wiki Build failure
+
+            Something went wrong while creating a test-build of the Wiki for this Pull request.
+            Please check the [Workflow Logs](${{ env.RUN_URL }}) for any errors.
+          issue-number: "${{ github.event.pull_request.number }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          edit-mode: replace


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes N/A <!-- If your PR is based on an issue, change "N/A" to the issue ID (#id) -->

Adds a Workflow that validates Pull requests for the wiki by executing `mkdocs build --strict`, which would error on any warnings it encounters during a build.

If the build fails will a Comment be sent here to inform about it, otherwise will nothing happen.

This should help to make sure that Wiki PRs are fine and don't contain issues such as broken (anchor) links or invalid nav configurations.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
