### PR TITLE
PAPIComponents Deserializer Support

### DIFF
--- a/src/paper/java/me/clip/placeholderapi/PAPIComponents.java
+++ b/src/paper/java/me/clip/placeholderapi/PAPIComponents.java
@@ -61,19 +61,19 @@ public final class PAPIComponents {
      *
      * @param player     Player to parse the placeholders against
      * @param component  Component to set the placeholder values in
-     * @param serializer Optional function to serialize parsed placeholder values into ComponentLike
+     * @param deserializer Optional function to serialize parsed placeholder values into ComponentLike
      * @return Component containing all translated placeholders
      */
     @NotNull
-    public static Component setPlaceholders(final OfflinePlayer player, @NotNull final Component component, @Nullable Function<String, ComponentLike> serializer) {
+    public static Component setPlaceholders(final OfflinePlayer player, @NotNull final Component component, @Nullable Function<String, ComponentLike> deserializer) {
         if (PlaceholderAPIPlugin.getInstance().getPlaceholderAPIConfig().useAdventureProvidedReplacer()) {
             return component.replaceText(config -> config.match(PlaceholderAPI.PLACEHOLDER_PATTERN).replacement((result, builder) -> {
                 String parsed = PERCENT_EXACT_REPLACER.apply(result.group(), player, PlaceholderAPIPlugin.getInstance().getLocalExpansionManager()::getExpansion);
-                return serializer == null ? builder.content(parsed) : serializer.apply(parsed);
+                return deserializer == null ? builder.content(parsed) : deserializer.apply(parsed);
             }));
         }
 
-        return ComponentReplacer.replace(component, str -> PlaceholderAPI.setPlaceholders(player, str), serializer == null ? null : s -> serializer.apply(s).asComponent());
+        return ComponentReplacer.replace(component, str -> PlaceholderAPI.setPlaceholders(player, str), deserializer == null ? null : s -> deserializer.apply(s).asComponent());
     }
 
     /**
@@ -95,12 +95,12 @@ public final class PAPIComponents {
      *
      * @param player     Player to parse the placeholders against
      * @param components List of Components to set the placeholder values in
-     * @param serializer Optional function to serialize parsed placeholder values into ComponentLike
+     * @param deserializer Optional function to serialize parsed placeholder values into ComponentLike
      * @return List of Components containing all translated placeholders
      */
     @NotNull
-    public static List<Component> setPlaceholders(final OfflinePlayer player, @NotNull final List<Component> components, @Nullable Function<String, ComponentLike> serializer) {
-        return components.stream().map(component -> setPlaceholders(player, component, serializer == null ? null : s -> serializer.apply(s).asComponent())).collect(Collectors.toList());
+    public static List<Component> setPlaceholders(final OfflinePlayer player, @NotNull final List<Component> components, @Nullable Function<String, ComponentLike> deserializer) {
+        return components.stream().map(component -> setPlaceholders(player, component, deserializer == null ? null : s -> deserializer.apply(s).asComponent())).collect(Collectors.toList());
     }
 
     /**
@@ -122,12 +122,12 @@ public final class PAPIComponents {
      *
      * @param player     Player to parse the placeholders against
      * @param component  Component to set the placeholder values in
-     * @param serializer Optional function to serialize parsed placeholder values into ComponentLike
+     * @param deserializer Optional function to serialize parsed placeholder values into ComponentLike
      * @return Component containing all translated placeholders
      */
     @NotNull
-    public static Component setPlaceholders(final Player player, @NotNull final Component component, @Nullable Function<String, ComponentLike> serializer) {
-        return setPlaceholders((OfflinePlayer) player, component, serializer);
+    public static Component setPlaceholders(final Player player, @NotNull final Component component, @Nullable Function<String, ComponentLike> deserializer) {
+        return setPlaceholders((OfflinePlayer) player, component, deserializer);
     }
 
     /**
@@ -149,12 +149,12 @@ public final class PAPIComponents {
      *
      * @param player     Player to parse the placeholders against
      * @param components List of Components to set the placeholder values in
-     * @param serializer Optional function to serialize parsed placeholder values into ComponentLike
+     * @param deserializer Optional function to serialize parsed placeholder values into ComponentLike
      * @return List of components containing all translated placeholders
      */
     @NotNull
-    public static List<Component> setPlaceholders(final Player player, @NotNull final List<Component> components, @Nullable Function<String, ComponentLike> serializer) {
-        return setPlaceholders((OfflinePlayer) player, components, serializer);
+    public static List<Component> setPlaceholders(final Player player, @NotNull final List<Component> components, @Nullable Function<String, ComponentLike> deserializer) {
+        return setPlaceholders((OfflinePlayer) player, components, deserializer);
     }
 
     /**
@@ -176,17 +176,17 @@ public final class PAPIComponents {
      *
      * @param player     Player to parse the placeholders against
      * @param component  Component to set the placeholder values in
-     * @param serializer Optional function to serialize parsed placeholder values into ComponentLike
+     * @param deserializer Optional function to serialize parsed placeholder values into ComponentLike
      * @return Component containing all translated placeholders
      */
     @NotNull
-    public static Component setBracketPlaceholders(final OfflinePlayer player, @NotNull final Component component, @Nullable Function<String, ComponentLike> serializer) {
+    public static Component setBracketPlaceholders(final OfflinePlayer player, @NotNull final Component component, @Nullable Function<String, ComponentLike> deserializer) {
         if (PlaceholderAPIPlugin.getInstance().getPlaceholderAPIConfig().useAdventureReplacer()) {
             return component.replaceText(config -> config.match(PlaceholderAPI.BRACKET_PLACEHOLDER_PATTERN).replacement((result, builder) ->
                     builder.content(BRACKET_EXACT_REPLACER.apply(result.group(), player, PlaceholderAPIPlugin.getInstance().getLocalExpansionManager()::getExpansion))));
         }
 
-        return ComponentReplacer.replace(component, str -> PlaceholderAPI.setBracketPlaceholders(player, str), serializer == null ? null : s -> serializer.apply(s).asComponent());
+        return ComponentReplacer.replace(component, str -> PlaceholderAPI.setBracketPlaceholders(player, str), deserializer == null ? null : s -> deserializer.apply(s).asComponent());
     }
 
     /**
@@ -208,12 +208,12 @@ public final class PAPIComponents {
      *
      * @param player     Player to parse the placeholders against
      * @param components List of Components to set the placeholder values in
-     * @param serializer Optional function to serialize parsed placeholder values into ComponentLike
+     * @param deserializer Optional function to serialize parsed placeholder values into ComponentLike
      * @return List of Components containing all translated placeholders
      */
     @NotNull
-    public static List<Component> setBracketPlaceholders(final OfflinePlayer player, @NotNull final List<Component> components, @Nullable Function<String, ComponentLike> serializer) {
-        return components.stream().map(component -> setBracketPlaceholders(player, component, serializer)).collect(Collectors.toList());
+    public static List<Component> setBracketPlaceholders(final OfflinePlayer player, @NotNull final List<Component> components, @Nullable Function<String, ComponentLike> deserializer) {
+        return components.stream().map(component -> setBracketPlaceholders(player, component, deserializer)).collect(Collectors.toList());
     }
 
     /**
@@ -235,12 +235,12 @@ public final class PAPIComponents {
      *
      * @param player     Player to parse the placeholders against
      * @param component  Component to set the placeholder values in
-     * @param serializer Optional function to serialize parsed placeholder values into ComponentLike
+     * @param deserializer Optional function to serialize parsed placeholder values into ComponentLike
      * @return Component containing all translated placeholders
      */
     @NotNull
-    public static Component setBracketPlaceholders(final Player player, @NotNull final Component component, @Nullable Function<String, ComponentLike> serializer) {
-        return setBracketPlaceholders((OfflinePlayer) player, component, serializer);
+    public static Component setBracketPlaceholders(final Player player, @NotNull final Component component, @Nullable Function<String, ComponentLike> deserializer) {
+        return setBracketPlaceholders((OfflinePlayer) player, component, deserializer);
     }
 
     /**
@@ -262,12 +262,12 @@ public final class PAPIComponents {
      *
      * @param player     Player to parse the placeholders against
      * @param components List of Components to set the placeholder values in
-     * @param serializer Optional function to serialize parsed placeholder values into ComponentLike
+     * @param deserializer Optional function to serialize parsed placeholder values into ComponentLike
      * @return List of Components containing all translated placeholders
      */
     @NotNull
-    public static List<Component> setBracketPlaceholders(final Player player, @NotNull final List<Component> components, @Nullable Function<String, ComponentLike> serializer) {
-        return setBracketPlaceholders((OfflinePlayer) player, components, serializer);
+    public static List<Component> setBracketPlaceholders(final Player player, @NotNull final List<Component> components, @Nullable Function<String, ComponentLike> deserializer) {
+        return setBracketPlaceholders((OfflinePlayer) player, components, deserializer);
     }
 
     /**

--- a/src/paper/java/me/clip/placeholderapi/replacer/ComponentReplacer.java
+++ b/src/paper/java/me/clip/placeholderapi/replacer/ComponentReplacer.java
@@ -18,25 +18,25 @@ import java.util.function.Function;
 
 public class ComponentReplacer {
     @NotNull
-    public static Component replace(@NotNull final Component component, @NotNull final Function<String, String> replacer, @Nullable final Function<String, Component> serializer) {
-        return rebuild(component, replacer, serializer);
+    public static Component replace(@NotNull final Component component, @NotNull final Function<String, String> replacer, @Nullable final Function<String, Component> deserializer) {
+        return rebuild(component, replacer, deserializer);
     }
 
     @NotNull
-    private static Component rebuild(@NotNull final Component component, @NotNull final Function<String, String> replacer, @Nullable final Function<String, Component> serializer) {
+    private static Component rebuild(@NotNull final Component component, @NotNull final Function<String, String> replacer, @Nullable final Function<String, Component> deserializer) {
         Component rebuilt;
 
         if (component instanceof TextComponent) {
             final TextComponent text = (TextComponent) component;
             final String replaced = replacer.apply(text.content());
 
-            rebuilt = serializer == null ? Component.text(replaced) : serializer.apply(replaced);
+            rebuilt = deserializer == null ? Component.text(replaced) : deserializer.apply(replaced);
         } else if (component instanceof TranslatableComponent) {
             final TranslatableComponent translatable = (TranslatableComponent) component;
             final List<Component> arguments = new ArrayList<>();
 
             for (final ComponentLike arg : translatable.arguments()) {
-                arguments.add(rebuild(arg.asComponent(), replacer, serializer));
+                arguments.add(rebuild(arg.asComponent(), replacer, deserializer));
             }
 
             rebuilt = Component.translatable(translatable.key(), arguments);
@@ -53,12 +53,12 @@ public class ComponentReplacer {
             rebuilt = Component.empty();
         }
 
-        rebuilt = rebuilt.style(rebuildStyle(component.style(), replacer, serializer));
+        rebuilt = rebuilt.style(rebuildStyle(component.style(), replacer, deserializer));
 
         if (!component.children().isEmpty()) {
             final List<Component> children = new ArrayList<>();
             for (Component child : component.children()) {
-                children.add(rebuild(child, replacer, serializer));
+                children.add(rebuild(child, replacer, deserializer));
             }
             rebuilt = rebuilt.children(children);
         }
@@ -67,7 +67,7 @@ public class ComponentReplacer {
     }
 
     @NotNull
-    private static Style rebuildStyle(@NotNull final Style style, @NotNull final Function<String, String> replacer, @Nullable final Function<String, Component> serializer) {
+    private static Style rebuildStyle(@NotNull final Style style, @NotNull final Function<String, String> replacer, @Nullable final Function<String, Component> deserializer) {
         final Style.Builder builder = style.toBuilder();
         final ClickEvent click = style.clickEvent();
 
@@ -78,7 +78,7 @@ public class ComponentReplacer {
         final HoverEvent<?> hover = style.hoverEvent();
 
         if (hover != null) {
-            builder.hoverEvent(rebuildHoverEvent(hover, replacer, serializer));
+            builder.hoverEvent(rebuildHoverEvent(hover, replacer, deserializer));
         }
 
         return builder.build();
@@ -114,11 +114,11 @@ public class ComponentReplacer {
     }
 
     @NotNull
-    private static HoverEvent<?> rebuildHoverEvent(@NotNull final HoverEvent<?> hover, @NotNull final Function<String, String> replacer, @Nullable final Function<String, Component> serializer) {
+    private static HoverEvent<?> rebuildHoverEvent(@NotNull final HoverEvent<?> hover, @NotNull final Function<String, String> replacer, @Nullable final Function<String, Component> deserializer) {
         final Object value = hover.value();
 
         if (value instanceof Component) {
-            final Component rebuilt = rebuild((Component) value, replacer, serializer);
+            final Component rebuilt = rebuild((Component) value, replacer, deserializer);
             return HoverEvent.showText(rebuilt);
         }
 
@@ -131,7 +131,7 @@ public class ComponentReplacer {
 
             Component rebuiltName = null;
             if (entity.name() != null) {
-                rebuiltName = rebuild(entity.name(), replacer, serializer);
+                rebuiltName = rebuild(entity.name(), replacer, deserializer);
             }
 
             return HoverEvent.showEntity(entity.type(), entity.id(), rebuiltName);


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
This change adds deserializer support to the component placeholder replacement methods in PAPIComponents.

Previously, placeholder replacements always returned raw strings that were directly inserted into the component tree, which made it difficult to properly deserialize formatted outputs (such as MiniMessage or hex-colored strings) during replacement. This often required an additional serialization/deserialization pass after placeholder parsing.

With this update, the replacement methods now accept an optional deserializer function that allows callers to convert parsed placeholder strings into ComponentLike values at replacement time. This enables correct handling of formatted placeholder outputs (e.g., MiniMessage, color codes, or custom formatting) without needing post-processing steps, while preserving full backwards compatibility through overloads that default the serializer to null.

This makes component placeholder parsing more flexible and allows formatted placeholder outputs to be applied directly during the replacement process.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
