### PR TITLE
fix: correct mmoskilltree placeholder name from %mmoskilltree_level_t…

### DIFF
--- a/docs/users/placeholder-list/hytale.md
+++ b/docs/users/placeholder-list/hytale.md
@@ -845,7 +845,7 @@ Members and relations:
 %mmoskilltree_all_xp%
 %mmoskilltree_all_levels%
 %mmoskilltree_total_xp%
-%mmoskilltree_level_total%
+%mmoskilltree_total_level%
 %mmoskilltree_calculate_level_from_xp_<xp>%
 %mmoskilltree_get_xp_for_level_<level>%
 %mmoskilltree_level_progress_<skill>%


### PR DESCRIPTION
…otal% to %mmoskilltree_total_level%

<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [ ] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [x] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->
fixes pigs typo
Closes N/A <!-- If your PR is based on an issue, change "N/A" to the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
