### PR TITLE
Fix safety check checking non-expansion files

### DIFF
--- a/src/main/java/me/clip/placeholderapi/util/ExpansionSafetyCheck.java
+++ b/src/main/java/me/clip/placeholderapi/util/ExpansionSafetyCheck.java
@@ -2,7 +2,6 @@ package me.clip.placeholderapi.util;
 
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
-import com.google.common.io.Resources;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.manager.CloudExpansionManager;
 import org.jetbrains.annotations.NotNull;
@@ -11,7 +10,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.net.URI;
-import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -63,7 +61,7 @@ public final class ExpansionSafetyCheck {
         }
 
         final Set<String> maliciousPaths = new HashSet<>();
-        final File[] files = expansionsFolder.listFiles();
+        final File[] files = expansionsFolder.listFiles((dir, name) -> name.endsWith(".jar"));
 
         if (files == null) {
             return false;


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description

Ignores any file that doesn't end with `.jar` when checking for malware. I thought that this would be fine since PlaceholderAPI only registers expansions when they end with `.jar`.

It also removes two unused imports.

Issued to fix this error:
```
[16:51:22 ERROR]: [PlaceholderAPI] Error occurred while trying to read /home/container/plugins/PlaceholderAPI/expansions/libraries
java.io.FileNotFoundException: plugins/PlaceholderAPI/expansions/libraries (Is a directory)
        at java.base/java.io.FileInputStream.open0(Native Method) ~[?:?]
        at java.base/java.io.FileInputStream.open(FileInputStream.java:185) ~[?:?]
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:139) ~[?:?]
        at com.google.common.io.Files$FileByteSource.openStream(Files.java:131) ~[guava-33.5.0-jre.jar:?]
        at com.google.common.io.Files$FileByteSource.read(Files.java:155) ~[guava-33.5.0-jre.jar:?]
        at PlaceholderAPI-2.12.2.jar//me.clip.placeholderapi.util.ExpansionSafetyCheck.runChecks(ExpansionSafetyCheck.java:61) ~[?:?]
        at PlaceholderAPI-2.12.2.jar//me.clip.placeholderapi.commands.impl.local.CommandReload.evaluate(CommandReload.java:42) ~[?:?]
        at PlaceholderAPI-2.12.2.jar//me.clip.placeholderapi.commands.PlaceholderCommandRouter.onCommand(PlaceholderCommandRouter.java:117) ~[?:?]
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.command.brigadier.bukkit.BukkitCommandNode$BukkitBrigCommand.run(BukkitCommandNode.java:83) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73) ~[brigadier-1.3.10.jar:?]
        at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:30) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:13) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.commands.execution.CommandQueueEntry.execute(CommandQueueEntry.java:5) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:104) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.commands.Commands.executeCommandInContext(Commands.java:469) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.commands.Commands.performCommand(Commands.java:374) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.commands.Commands.performCommand(Commands.java:362) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.commands.Commands.performPrefixedCommand(Commands.java:353) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.server.dedicated.DedicatedServer.handleConsoleInputs(DedicatedServer.java:594) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.server.dedicated.DedicatedServer.tickConnection(DedicatedServer.java:550) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1833) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1611) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:427) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1667) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1335) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:388) ~[paper-1.21.11.jar:1.21.11-132-c5eb079]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
```
<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
