### PR TITLE
Add support for 2-digit and 3-digit Minecraft version formats

### DIFF
--- a/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
+++ b/src/main/java/me/clip/placeholderapi/PlaceholderAPIPlugin.java
@@ -61,16 +61,29 @@ public final class PlaceholderAPIPlugin extends JavaPlugin {
 
     static {
         String version = Bukkit.getServer().getBukkitVersion().split("-")[0];
-        String suffix;
-        if (version.chars()
-                .filter(c -> c == '.')
-                .count() == 1) {
-            suffix = "R1";
-            version = 'v' + version.replace('.', '_') + '_' + suffix;
-        } else {
-            int minor = Integer.parseInt(version.split("\\.")[2].charAt(0) + "");
-            version = 'v' + version.replace('.', '_').replace("_" + minor, "") + '_' + "R" + (minor - 1);
+        String[] parts = version.split("\\.");
+        String major = parts.length > 0 ? parts[0] : "0";
+        String minor = parts.length > 1 ? parts[1] : "0";
+        String patch = null;
+        if (parts.length > 2) {
+            patch = parts[2];
         }
+        
+        String suffix;
+        // Case: 26.2  → only 2 numbers
+        if (patch == null) {
+            suffix = "R1";
+        }
+        // Case: 26.1.2 → 3 numbers
+        else {
+            try {
+                int patchNum = Integer.parseInt(patch.replaceAll("\\D", ""));
+                suffix = "R" + Math.max(1, patchNum);
+            } catch (Exception e) {
+                suffix = "R1";
+            }
+        }
+        version = "v" + major + "_" + minor + "_" + suffix;
 
         boolean isSpigot;
         try {


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [X] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Closes #1226 <!-- If your PR is based on an issue, change "N/A" to the issue ID (#id) -->

The previous version parsing logic assumed a fixed numeric structure and did not account for newer Bukkit/Paper version formats introduced in 26.x.

Modern versions may include variable-length identifiers such as "26.2.build.11-alpha", which caused parsing failures when non-numeric segments (e.g. "build") were processed as integers.

This change improves compatibility by normalizing the version string, safely handling both 2-part (26.2) and 3-part (1.21.11) formats to prevent runtime exceptions.

<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
