### PR TITLE
fix(logging): improve local expansion failure diagnostics

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -455,7 +455,7 @@ public final class LocalExpansionManager implements Listener {
                 throw ((LinkageError) ex.getCause());
             }
 
-            Msg.warn("There was an issue with loading an expansion.");
+            Msg.severe("Failed to create expansion instance for class %s.", ex, clazz.getName());
             return null;
         }
     }

--- a/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/LocalExpansionManager.java
@@ -94,7 +94,7 @@ public final class LocalExpansionManager implements Listener {
         this.folder = new File(plugin.getDataFolder(), EXPANSIONS_FOLDER_NAME);
 
         if (!this.folder.exists() && !folder.mkdirs()) {
-            Msg.warn("Failed to create expansions folder!");
+            plugin.getLogger().warning("Failed to create expansions folder!");
         }
     }
 


### PR DESCRIPTION
<!--
  ### Please read ###
  Please make sure you checked the following:

  - You checked the Pull requests page for any upcoming changes.
  - You documented any public code that the end-user might use.
  - You followed the contributing file (https://github.com/PlaceholderAPI/PlaceholderAPI/tree/master/.github/CONTRIBUTING.md).
-->

## Pull Request

### Type
<!--
      Please select the right one, by changing the [ ] to [x]
-->
- [X] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________ <!-- Use this if none of the above matches your request -->

### Description
<!-- What does your Pull request change? -->

Fixes #1225.
Fixes #1132.

This improves `LocalExpansionManager` failure logging in two places.

First, local expansion instantiation failures now include the thrown exception and stack trace. Previously, constructor/reflection failures only logged a generic warning, making it difficult to diagnose why an expansion failed to load. The existing `LinkageError` unwrap behavior is preserved so missing-dependency cases still flow through the existing outer error handling.

Second, the `LocalExpansionManager` constructor now logs through the provided plugin instance instead of `Msg.warn(...)`. `LocalExpansionManager` is constructed before `PlaceholderAPIPlugin.onLoad()` assigns the static plugin instance, so using `Msg.warn(...)` during construction can throw a `NullPointerException` if the expansions folder cannot be created. Logging through the provided plugin instance allows the intended warning to be emitted without failing plugin initialization.


<!-- If your PR is based on an issue, change "N/A" to the issue ID (#id) -->


<!-- DO NOT ALTER ANYTHING BELOW THIS LINE! -->
[Wiki]: https://wiki.placeholderapi.com
