### PR TITLE
Use ConcurrentHashMap for CloudExpansionManager cache

### DIFF
--- a/src/main/java/me/clip/placeholderapi/expansion/manager/CloudExpansionManager.java
+++ b/src/main/java/me/clip/placeholderapi/expansion/manager/CloudExpansionManager.java
@@ -34,7 +34,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -94,7 +93,7 @@ public final class CloudExpansionManager {
     private final PlaceholderAPIPlugin plugin;
 
     @NotNull
-    private final Map<String, CloudExpansion> cache = new HashMap<>();
+    private final Map<String, CloudExpansion> cache = new ConcurrentHashMap<>();
     @NotNull
     private final Map<String, CompletableFuture<File>> await = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
## Pull Request

### Type
- [x] Internal change (Doesn't affect end-user).
- [ ] External change (Does affect end-user).
- [ ] Wiki (Changes towards the [Wiki]).
- [ ] Other: __________

### Description
The `cache` field in `CloudExpansionManager` is a plain `HashMap` that is read from multiple public methods (`getCloudExpansions()`, `findCloudExpansionByName()`, `getCloudExpansionsInstalled()`, `getCloudExpansionsByAuthor()`, `getCloudExpansionAuthors()`, `isEmpty()`) and written to from `fetch()` (via the async-then-main-thread callback) and `clean()`.

Since these public read methods can be called from any thread while the async `fetch()` completes on the main thread, this creates a potential `ConcurrentModificationException` risk when iterating the map (e.g. via `ImmutableMap.copyOf(cache)` or streams over `cache.values()`).

The sister class `LocalExpansionManager` already uses `ConcurrentHashMap` for its `expansions` map, and the local `values` map inside `fetch()` in this same class already uses `ConcurrentHashMap` with an explicit comment:
```java
// a defence tactic! use ConcurrentHashMap instead of normal HashMap
Map<String, CloudExpansion> values = new ConcurrentHashMap<>();